### PR TITLE
implemented the AnalyticsExposure fetch endpoint and required types

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -180,7 +180,12 @@ class BackgroundTasks(threading.Thread):
 
             while True:
                 try:
-                    # UE = crud.ue.update_coordinates(db=db, lat=points[current_position_index]["latitude"], long=points[current_position_index]["longitude"], db_obj=UE)
+                    crud.ue.update_coordinates(
+                        db=self._db,
+                        lat=ues[f"{supi}"]["latitude"],
+                        long=ues[f"{supi}"]["longitude"],
+                        db_obj=UE,
+                    )
                     # cell_now = check_distance(UE.latitude, UE.longitude, json_cells) #calculate the distance from all the cells
                     ues[f"{supi}"]["latitude"] = points[current_position_index]["latitude"]
                     ues[f"{supi}"]["longitude"] = points[current_position_index]["longitude"]


### PR DESCRIPTION
The /fetch was implemented for requests of UE_MOBILITY events, not allowing any filtering and allowing only for the request of a single device. While all the required types by the specification were implemented, the endpoint only returns the location of the UE.