### PR TITLE
Location Notification and Monitoring Event Refactoring

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/analyticsExposure.py
+++ b/backend/app/app/api/api_v1/endpoints/analyticsExposure.py
@@ -280,13 +280,23 @@ def fetch_analytics(
     if not item_in.tgtUe.gpsi:
         raise HTTPException(status_code=501, detail="Not Implemented")
 
+    user_equipment = None
     try:
-        user_equipment = ue.get_supi(db, supi=item_in.tgtUe.gpsi)
+        tgtUe: str = item_in.tgtUe.gpsi
+        if tgtUe.startswith("msisdn-"):
+            user_equipment = ue.get_supi(db, supi=tgtUe.split("msisdn-")[1])
+
+        elif tgtUe.startswith("extid-"):
+            user_equipment = ue.get_externalId(
+                db, externalId=tgtUe.split("extid-")[1], owner_id=current_user.id
+            )
 
     except Exception as ex:
         raise HTTPException(status_code=404, detail="The current device was not found")
 
-    print(user_equipment)
+    if user_equipment is None:
+        raise HTTPException(status_code=404, detail="The current device was not found")
+
     point = Point(
         shape="POINT",
         point=GeographicalCoordinates(

--- a/backend/app/app/api/api_v1/endpoints/analyticsExposure.py
+++ b/backend/app/app/api/api_v1/endpoints/analyticsExposure.py
@@ -1,7 +1,13 @@
 from typing import Any, List
 
 from requests import status_codes
-from app.schemas.analyticsExposure import LocationArea5G, UeLocationInfo, AnalyticsEvent
+from app.schemas.analyticsExposure import (
+    LocationArea5G,
+    UeLocationInfo,
+    AnalyticsEvent,
+    UeMobilityExposure,
+    AnalyticsData,
+)
 from app.schemas.monitoringevent import GeographicArea, GeographicalCoordinates, Point
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, Request
 from fastapi.encoders import jsonable_encoder
@@ -14,33 +20,42 @@ from app.api import deps
 from app import tools
 from app.db.session import client
 from app.api.api_v1.endpoints.utils import add_notifications
-from .ue_movement import retrieve_ue_state, retrieve_ue
 
 router = APIRouter()
-db_collection= 'AnalyticsExposure'
+db_collection = "AnalyticsExposure"
 
-@router.get("/{afId}/subscriptions", response_model=List[schemas.AnalyticsExposureSubsc], responses={204: {"model" : None}})
+
+@router.get(
+    "/{afId}/subscriptions",
+    response_model=List[schemas.AnalyticsExposureSubsc],
+    responses={204: {"model": None}},
+)
 def read_active_subscriptions(
     *,
-    afId: str = Path(..., title="The ID of the Netapp that read all the subscriptions", example="myNetapp"),
+    afId: str = Path(
+        ...,
+        title="The ID of the Netapp that read all the subscriptions",
+        example="myNetapp",
+    ),
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Read all active subscriptions
-    """    
+    """
     db_mongo = client.fastapi
     retrieved_docs = crud_mongo.read_all(db_mongo, db_collection, current_user.id)
 
-    #Check if there are any active subscriptions
+    # Check if there are any active subscriptions
     if not retrieved_docs:
         raise HTTPException(status_code=404, detail="There are no active subscriptions")
-    
+
     http_response = JSONResponse(content=retrieved_docs, status_code=200)
     add_notifications(http_request, http_response, False)
     return http_response
 
-# #Callback 
+
+# #Callback
 
 # analytics_exposure_callback_router = APIRouter()
 
@@ -48,50 +63,72 @@ def read_active_subscriptions(
 # def analytics_exposure_notification(body: schemas.AnalyticsEventNotification):
 #     pass
 
-@router.post("/{afId}/subscriptions", response_model=schemas.AnalyticsExposureSubsc, responses={201: {"model" : schemas.AnalyticsExposureSubsc}})
+
+@router.post(
+    "/{afId}/subscriptions",
+    response_model=schemas.AnalyticsExposureSubsc,
+    responses={201: {"model": schemas.AnalyticsExposureSubsc}},
+)
 def create_subscription(
     *,
-    afId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    afId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     db: Session = Depends(deps.get_db),
     item_in: schemas.AnalyticsExposureSubscCreate,
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Create new subscription.
     """
     db_mongo = client.fastapi
     json_data = jsonable_encoder(item_in)
-    json_data.update({'owner_id' : current_user.id})
+    json_data.update({"owner_id": current_user.id})
 
     inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
 
-    #Create the reference resource and location header
-    link = str(http_request.url) + '/' + str(inserted_doc.inserted_id)
-    response_header = {"location" : link}
+    # Create the reference resource and location header
+    link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
+    response_header = {"location": link}
 
-    #Update the subscription with the new resource (link) and return the response (+response header)
-    crud_mongo.update_new_field(db_mongo, db_collection, inserted_doc.inserted_id, {"link" : link})
-    
-    #Retrieve the updated document | UpdateResult is not a dict
-    updated_doc = crud_mongo.read_uuid(db_mongo, db_collection, inserted_doc.inserted_id)
+    # Update the subscription with the new resource (link) and return the response (+response header)
+    crud_mongo.update_new_field(
+        db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
+    )
 
-    updated_doc.pop("owner_id") #Remove owner_id from the response
+    # Retrieve the updated document | UpdateResult is not a dict
+    updated_doc = crud_mongo.read_uuid(
+        db_mongo, db_collection, inserted_doc.inserted_id
+    )
 
-    http_response = JSONResponse(content=updated_doc, status_code=201, headers=response_header)
+    updated_doc.pop("owner_id")  # Remove owner_id from the response
+
+    http_response = JSONResponse(
+        content=updated_doc, status_code=201, headers=response_header
+    )
     add_notifications(http_request, http_response, False)
 
     return http_response
 
 
-@router.put("/{afId}/subscriptions/{subscriptionId}", response_model=schemas.AnalyticsExposureSubsc)
+@router.put(
+    "/{afId}/subscriptions/{subscriptionId}",
+    response_model=schemas.AnalyticsExposureSubsc,
+)
 def update_subscription(
     *,
-    afId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    afId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     subscriptionId: str = Path(..., title="Identifier of the subscription resource"),
     item_in: schemas.AnalyticsExposureSubscCreate,
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Update/Replace an existing subscription resource by id
@@ -101,33 +138,46 @@ def update_subscription(
     try:
         retrieved_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     except Exception as ex:
-        raise HTTPException(status_code=400, detail='Please enter a valid uuid (24-character hex string)')
-    
-    #Check if the document exists
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a valid uuid (24-character hex string)",
+        )
+
+    # Check if the document exists
     if not retrieved_doc:
         raise HTTPException(status_code=404, detail="Subscription not found")
-    #If the document exists then validate the owner
-    if not user.is_superuser(current_user) and (retrieved_doc['owner_id'] != current_user.id):
+    # If the document exists then validate the owner
+    if not user.is_superuser(current_user) and (
+        retrieved_doc["owner_id"] != current_user.id
+    ):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
-    #Update the document
+    # Update the document
     json_data = jsonable_encoder(item_in)
     crud_mongo.update_new_field(db_mongo, db_collection, subscriptionId, json_data)
 
-    #Retrieve the updated document | UpdateResult is not a dict
+    # Retrieve the updated document | UpdateResult is not a dict
     updated_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     updated_doc.pop("owner_id")
     http_response = JSONResponse(content=updated_doc, status_code=200)
     add_notifications(http_request, http_response, False)
     return http_response
 
-@router.get("/{afId}/subscriptions/{subscriptionId}", response_model=schemas.MonitoringEventSubscription)
+
+@router.get(
+    "/{afId}/subscriptions/{subscriptionId}",
+    response_model=schemas.MonitoringEventSubscription,
+)
 def read_subscription(
     *,
-    afId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    afId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     subscriptionId: str = Path(..., title="Identifier of the subscription resource"),
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Get subscription by id
@@ -137,27 +187,40 @@ def read_subscription(
     try:
         retrieved_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     except Exception as ex:
-        raise HTTPException(status_code=400, detail='Please enter a valid uuid (24-character hex string)')
-    
-    #Check if the document exists
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a valid uuid (24-character hex string)",
+        )
+
+    # Check if the document exists
     if not retrieved_doc:
         raise HTTPException(status_code=404, detail="Subscription not found")
-    #If the document exists then validate the owner
-    if not user.is_superuser(current_user) and (retrieved_doc['owner_id'] != current_user.id):
+    # If the document exists then validate the owner
+    if not user.is_superuser(current_user) and (
+        retrieved_doc["owner_id"] != current_user.id
+    ):
         raise HTTPException(status_code=400, detail="Not enough permissions")
-    
+
     retrieved_doc.pop("owner_id")
     http_response = JSONResponse(content=retrieved_doc, status_code=200)
     add_notifications(http_request, http_response, False)
     return http_response
 
-@router.delete("/{afId}/subscriptions/{subscriptionId}", response_model=schemas.AnalyticsExposureSubsc)
+
+@router.delete(
+    "/{afId}/subscriptions/{subscriptionId}",
+    response_model=schemas.AnalyticsExposureSubsc,
+)
 def delete_subscription(
     *,
-    afId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    afId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     subscriptionId: str = Path(..., title="Identifier of the subscription resource"),
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Delete a subscription
@@ -167,23 +230,24 @@ def delete_subscription(
     try:
         retrieved_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     except Exception as ex:
-        raise HTTPException(status_code=400, detail='Please enter a valid uuid (24-character hex string)')
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a valid uuid (24-character hex string)",
+        )
 
-
-    #Check if the document exists
+    # Check if the document exists
     if not retrieved_doc:
         raise HTTPException(status_code=404, detail="Subscription not found")
-    #If the document exists then validate the owner
-    if not user.is_superuser(current_user) and (retrieved_doc['owner_id'] != current_user.id):
+    # If the document exists then validate the owner
+    if not user.is_superuser(current_user) and (
+        retrieved_doc["owner_id"] != current_user.id
+    ):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
     crud_mongo.delete_by_uuid(db_mongo, db_collection, subscriptionId)
     http_response = JSONResponse(content=retrieved_doc, status_code=200)
     add_notifications(http_request, http_response, False)
     return http_response
-    
-    
-    
 
 
 @router.post("/{afId}/fetch")
@@ -217,9 +281,7 @@ def fetch_analytics(
         raise HTTPException(status_code=501, detail="Not Implemented")
 
     try:
-        user_equipment = ue.get_externalId(
-            db, externalId=item_in.tgtUe.gpsi, owner_id=current_user.id
-        )
+        user_equipment = ue.get_supi(db, supi=item_in.tgtUe.gpsi)
 
     except Exception as ex:
         raise HTTPException(status_code=404, detail="The current device was not found")
@@ -232,5 +294,9 @@ def fetch_analytics(
         ),
     )
     loc = LocationArea5G(geographicAreas=[point])
-    response = UeLocationInfo(loc=loc)
+    locInfo = UeLocationInfo(loc=loc)
+    mobilityExposure = UeMobilityExposure(
+        locInfo=[locInfo],
+    )
+    response = AnalyticsData(ueMobilityInfos=[mobilityExposure], suppFeat="")
     return response

--- a/backend/app/app/api/api_v1/endpoints/monitoringevent.py
+++ b/backend/app/app/api/api_v1/endpoints/monitoringevent.py
@@ -15,29 +15,44 @@ from .utils import ReportLogging
 
 router = APIRouter()
 router.route_class = ReportLogging
-db_collection= 'MonitoringEvent'
+db_collection = "MonitoringEvent"
 
-@router.get("/{scsAsId}/subscriptions", response_model=List[schemas.MonitoringEventSubscription], responses={204: {"model" : None}})
+
+@router.get(
+    "/{scsAsId}/subscriptions",
+    response_model=List[schemas.MonitoringEventSubscription],
+    responses={204: {"model": None}},
+)
 def read_active_subscriptions(
     *,
-    scsAsId: str = Path(..., title="The ID of the Netapp that read all the subscriptions", example="myNetapp"),
+    scsAsId: str = Path(
+        ...,
+        title="The ID of the Netapp that read all the subscriptions",
+        example="myNetapp",
+    ),
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Read all active subscriptions
-    """    
+    """
     db_mongo = client.fastapi
 
     retrieved_docs = crud_mongo.read_all(db_mongo, db_collection, current_user.id)
-    temp_json_subs = retrieved_docs.copy() #Create copy of the list (json_subs) -> you cannot remove items from a list while you iterating the list.
+    temp_json_subs = (
+        retrieved_docs.copy()
+    )  # Create copy of the list (json_subs) -> you cannot remove items from a list while you iterating the list.
 
     for sub in temp_json_subs:
-        sub_validate_time = tools.check_expiration_time(expire_time=sub.get("monitorExpireTime"))
+        sub_validate_time = tools.check_expiration_time(
+            expire_time=sub.get("monitorExpireTime")
+        )
         if not sub_validate_time:
-            crud_mongo.delete_by_item(db_mongo, db_collection, "externalId", sub.get("externalId"))
+            crud_mongo.delete_by_item(
+                db_mongo, db_collection, "externalId", sub.get("externalId")
+            )
             retrieved_docs.remove(sub)
-            
+
     temp_json_subs.clear()
 
     if retrieved_docs:
@@ -48,132 +63,201 @@ def read_active_subscriptions(
         return Response(status_code=204)
 
 
-
-#Callback 
+# Callback
 
 monitoring_callback_router = APIRouter()
 
-@monitoring_callback_router.post("{$request.body.notificationDestination}", response_model=schemas.MonitoringEventReportReceived, status_code=200, response_class=Response)
+
+@monitoring_callback_router.post(
+    "{$request.body.notificationDestination}",
+    response_model=schemas.MonitoringEventReportReceived,
+    status_code=200,
+    response_class=Response,
+)
 def monitoring_notification(body: schemas.MonitoringNotification):
     pass
 
-@router.post("/{scsAsId}/subscriptions", response_model=schemas.MonitoringEventSubscription, responses={201: {"model" : schemas.MonitoringEventSubscription}}, callbacks=monitoring_callback_router.routes)
+
+@router.post(
+    "/{scsAsId}/subscriptions",
+    response_model=schemas.MonitoringEventSubscription,
+    responses={201: {"model": schemas.MonitoringEventSubscription}},
+    callbacks=monitoring_callback_router.routes,
+)
 def create_subscription(
     *,
-    scsAsId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    scsAsId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     db: Session = Depends(deps.get_db),
     item_in: schemas.MonitoringEventSubscriptionCreate,
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Create new subscription.
     """
     db_mongo = client.fastapi
 
-    UE = ue.get_externalId(db=db, externalId=str(item_in.externalId), owner_id=current_user.id)
-    if not UE: 
-        raise HTTPException(status_code=409, detail="UE with this external identifier doesn't exist")
-    
-    
-    #One time request
-    if item_in.monitoringType == "LOCATION_REPORTING" and item_in.maximumNumberOfReports == 1:
-        
+    UE = ue.get_externalId(
+        db=db, externalId=str(item_in.externalId), owner_id=current_user.id
+    )
+    if not UE:
+        raise HTTPException(
+            status_code=409, detail="UE with this external identifier doesn't exist"
+        )
+
+    isByMaxReports = item_in.maximumNumberOfReports
+
+    isByExpireTime = item_in.monitorExpireTime is not None
+
+    if not (isByExpireTime or isByMaxReports):
+        raise HTTPException(
+            status_code=400,
+            detail="The request must contain either a maximumNumberOfReports or a monitorExpireTime",
+        )
+
+    # One time request
+    if (
+        item_in.monitoringType == "LOCATION_REPORTING"
+        and item_in.maximumNumberOfReports == 1
+    ):
+
         json_compatible_item_data = {}
         json_compatible_item_data["monitoringType"] = item_in.monitoringType
         json_compatible_item_data["externalId"] = item_in.externalId
         json_compatible_item_data["ipv4Addr"] = UE.ip_address_v4
 
-        
         if UE.Cell != None:
-            #If ue is moving retieve ue's information from memory else retrieve info from db
+            # If ue is moving retieve ue's information from memory else retrieve info from db
             if retrieve_ue_state(supi=UE.supi, user_id=current_user.id):
                 cell_id_hex = retrieve_ue(UE.supi).get("cell_id_hex")
                 gnb_id_hex = retrieve_ue(UE.supi).get("gnb_id_hex")
-                json_compatible_item_data["locationInfo"] = {'cellId' : cell_id_hex, 'gNBId' : gnb_id_hex}
+                json_compatible_item_data["locationInfo"] = {
+                    "cellId": cell_id_hex,
+                    "gNBId": gnb_id_hex,
+                }
             else:
-                json_compatible_item_data["locationInfo"] = {'cellId' : UE.Cell.cell_id, 'gNBId' : UE.Cell.gNB.gNB_id}
+                json_compatible_item_data["locationInfo"] = {
+                    "cellId": UE.Cell.cell_id,
+                    "gNBId": UE.Cell.gNB.gNB_id,
+                }
         else:
-            json_compatible_item_data["locationInfo"] = {'cellId' : None, 'gNBId' : None}
+            json_compatible_item_data["locationInfo"] = {"cellId": None, "gNBId": None}
 
         http_response = JSONResponse(content=json_compatible_item_data, status_code=200)
         add_notifications(http_request, http_response, False)
-        
-        return http_response 
-    #Subscription
-    elif item_in.monitoringType == "LOCATION_REPORTING" and item_in.maximumNumberOfReports>1:
-        
-        #Check if subscription with externalid exists
-        if crud_mongo.read_by_multiple_pairs(db_mongo, db_collection, externalId = item_in.externalId, monitoringType = item_in.monitoringType):
-            raise HTTPException(status_code=409, detail=f"There is already an active subscription for UE with external id {item_in.externalId} - Monitoring Type = {item_in.monitoringType}")
-   
+
+        return http_response
+    # Subscription
+
+    elif item_in.monitoringType == "LOCATION_REPORTING" and (
+        isByMaxReports or isByExpireTime
+    ):
+
         json_data = jsonable_encoder(item_in.dict(exclude_unset=True))
-        json_data.update({'owner_id' : current_user.id, "ipv4Addr" : UE.ip_address_v4})
+        json_data.update({"owner_id": current_user.id, "ipv4Addr": UE.ip_address_v4})
 
-        inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data) 
-        
-        #Create the reference resource and location header
-        link = str(http_request.url) + '/' + str(inserted_doc.inserted_id)
-        response_header = {"location" : link}
-        
-        #Update the subscription with the new resource (link) and return the response (+response header)
-        crud_mongo.update_new_field(db_mongo, db_collection, inserted_doc.inserted_id, {"link" : link})
+        inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
 
-        #Retrieve the updated document | UpdateResult is not a dict
-        updated_doc = crud_mongo.read_uuid(db_mongo, db_collection, inserted_doc.inserted_id)
+        # Create the reference resource and location header
+        link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
+        response_header = {"location": link}
+
+        # Update the subscription with the new resource (link) and return the response (+response header)
+        crud_mongo.update_new_field(
+            db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
+        )
+
+        # Retrieve the updated document | UpdateResult is not a dict
+        updated_doc = crud_mongo.read_uuid(
+            db_mongo, db_collection, inserted_doc.inserted_id
+        )
         updated_doc.pop("owner_id")
 
-
-        http_response = JSONResponse(content=updated_doc, status_code=201, headers=response_header)
+        http_response = JSONResponse(
+            content=updated_doc, status_code=201, headers=response_header
+        )
         add_notifications(http_request, http_response, False)
-        
+
         return http_response
-    elif (item_in.monitoringType == "LOSS_OF_CONNECTIVITY" or item_in.monitoringType == "UE_REACHABILITY") and item_in.maximumNumberOfReports == 1:
-        return JSONResponse(content=jsonable_encoder(
-            {
-                "title" : "The requested parameters are out of range",
-                "invalidParams" : {
-                    "param" : "maximumNumberOfReports",
-                    "reason" : "\"maximumNumberOfReports\" should be greater than 1 in case of LOSS_OF_CONNECTIVITY event"
+    elif (
+        item_in.monitoringType == "LOSS_OF_CONNECTIVITY"
+        or item_in.monitoringType == "UE_REACHABILITY"
+    ) and item_in.maximumNumberOfReports == 1:
+        return JSONResponse(
+            content=jsonable_encoder(
+                {
+                    "title": "The requested parameters are out of range",
+                    "invalidParams": {
+                        "param": "maximumNumberOfReports",
+                        "reason": '"maximumNumberOfReports" should be greater than 1 in case of LOSS_OF_CONNECTIVITY event',
+                    },
                 }
-            }
-        ), status_code=403)
-    elif (item_in.monitoringType == "LOSS_OF_CONNECTIVITY" or item_in.monitoringType == "UE_REACHABILITY") and item_in.maximumNumberOfReports > 1:
-        #Check if subscription with externalid && monitoringType exists
-        if crud_mongo.read_by_multiple_pairs(db_mongo, db_collection, externalId = item_in.externalId, monitoringType = item_in.monitoringType):
-            raise HTTPException(status_code=409, detail=f"There is already an active subscription for UE with external id {item_in.externalId} - Monitoring Type = {item_in.monitoringType}")
-   
+            ),
+            status_code=403,
+        )
+    elif (
+        item_in.monitoringType == "LOSS_OF_CONNECTIVITY"
+        or item_in.monitoringType == "UE_REACHABILITY"
+    ) and (isByMaxReports or isByExpireTime):
+        # Check if subscription with externalid && monitoringType exists
+        if crud_mongo.read_by_multiple_pairs(
+            db_mongo,
+            db_collection,
+            externalId=item_in.externalId,
+            monitoringType=item_in.monitoringType,
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail=f"There is already an active subscription for UE with external id {item_in.externalId} - Monitoring Type = {item_in.monitoringType}",
+            )
+
         json_data = jsonable_encoder(item_in.dict(exclude_unset=True))
-        json_data.update({'owner_id' : current_user.id, "ipv4Addr" : UE.ip_address_v4})
+        json_data.update({"owner_id": current_user.id, "ipv4Addr": UE.ip_address_v4})
 
-        inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data) 
-        
-        #Create the reference resource and location header
-        link = str(http_request.url) + '/' + str(inserted_doc.inserted_id)
-        response_header = {"location" : link}
-        
-        #Update the subscription with the new resource (link) and return the response (+response header)
-        crud_mongo.update_new_field(db_mongo, db_collection, inserted_doc.inserted_id, {"link" : link})
+        inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
 
-        #Retrieve the updated document | UpdateResult is not a dict
-        updated_doc = crud_mongo.read_uuid(db_mongo, db_collection, inserted_doc.inserted_id)
+        # Create the reference resource and location header
+        link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
+        response_header = {"location": link}
+
+        # Update the subscription with the new resource (link) and return the response (+response header)
+        crud_mongo.update_new_field(
+            db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
+        )
+
+        # Retrieve the updated document | UpdateResult is not a dict
+        updated_doc = crud_mongo.read_uuid(
+            db_mongo, db_collection, inserted_doc.inserted_id
+        )
         updated_doc.pop("owner_id")
 
-
-        http_response = JSONResponse(content=updated_doc, status_code=201, headers=response_header)
+        http_response = JSONResponse(
+            content=updated_doc, status_code=201, headers=response_header
+        )
         add_notifications(http_request, http_response, False)
 
         return http_response
 
 
-@router.put("/{scsAsId}/subscriptions/{subscriptionId}", response_model=schemas.MonitoringEventSubscription)
+@router.put(
+    "/{scsAsId}/subscriptions/{subscriptionId}",
+    response_model=schemas.MonitoringEventSubscription,
+)
 def update_subscription(
     *,
-    scsAsId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    scsAsId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     subscriptionId: str = Path(..., title="Identifier of the subscription resource"),
     item_in: schemas.MonitoringEventSubscriptionCreate,
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Update/Replace an existing subscription resource
@@ -183,23 +267,30 @@ def update_subscription(
     try:
         retrieved_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     except Exception as ex:
-        raise HTTPException(status_code=400, detail='Please enter a valid uuid (24-character hex string)')
-    
-    #Check if the document exists
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a valid uuid (24-character hex string)",
+        )
+
+    # Check if the document exists
     if not retrieved_doc:
         raise HTTPException(status_code=404, detail="Subscription not found")
-    #If the document exists then validate the owner
-    if not user.is_superuser(current_user) and (retrieved_doc['owner_id'] != current_user.id):
+    # If the document exists then validate the owner
+    if not user.is_superuser(current_user) and (
+        retrieved_doc["owner_id"] != current_user.id
+    ):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
-    sub_validate_time = tools.check_expiration_time(expire_time=retrieved_doc.get("monitorExpireTime"))
-    
+    sub_validate_time = tools.check_expiration_time(
+        expire_time=retrieved_doc.get("monitorExpireTime")
+    )
+
     if sub_validate_time:
-        #Update the document
+        # Update the document
         json_data = jsonable_encoder(item_in)
         crud_mongo.update_new_field(db_mongo, db_collection, subscriptionId, json_data)
-        
-        #Retrieve the updated document | UpdateResult is not a dict
+
+        # Retrieve the updated document | UpdateResult is not a dict
         updated_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
         updated_doc.pop("owner_id")
 
@@ -209,15 +300,22 @@ def update_subscription(
     else:
         crud_mongo.delete_by_uuid(db_mongo, db_collection, subscriptionId)
         raise HTTPException(status_code=403, detail="Subscription has expired")
-    
 
-@router.get("/{scsAsId}/subscriptions/{subscriptionId}", response_model=schemas.MonitoringEventSubscription)
+
+@router.get(
+    "/{scsAsId}/subscriptions/{subscriptionId}",
+    response_model=schemas.MonitoringEventSubscription,
+)
 def read_subscription(
     *,
-    scsAsId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    scsAsId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     subscriptionId: str = Path(..., title="Identifier of the subscription resource"),
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Get subscription by id
@@ -227,17 +325,24 @@ def read_subscription(
     try:
         retrieved_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     except Exception as ex:
-        raise HTTPException(status_code=400, detail='Please enter a valid uuid (24-character hex string)')
-    
-    #Check if the document exists
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a valid uuid (24-character hex string)",
+        )
+
+    # Check if the document exists
     if not retrieved_doc:
         raise HTTPException(status_code=404, detail="Subscription not found")
-    #If the document exists then validate the owner
-    if not user.is_superuser(current_user) and (retrieved_doc['owner_id'] != current_user.id):
+    # If the document exists then validate the owner
+    if not user.is_superuser(current_user) and (
+        retrieved_doc["owner_id"] != current_user.id
+    ):
         raise HTTPException(status_code=400, detail="Not enough permissions")
-    
-    sub_validate_time = tools.check_expiration_time(expire_time=retrieved_doc.get("monitorExpireTime"))
-    
+
+    sub_validate_time = tools.check_expiration_time(
+        expire_time=retrieved_doc.get("monitorExpireTime")
+    )
+
     if sub_validate_time:
         retrieved_doc.pop("owner_id")
         http_response = JSONResponse(content=retrieved_doc, status_code=200)
@@ -248,29 +353,42 @@ def read_subscription(
         crud_mongo.delete_by_uuid(db_mongo, db_collection, subscriptionId)
         raise HTTPException(status_code=403, detail="Subscription has expired")
 
-@router.delete("/{scsAsId}/subscriptions/{subscriptionId}", response_model=schemas.MonitoringEventSubscription)
+
+@router.delete(
+    "/{scsAsId}/subscriptions/{subscriptionId}",
+    response_model=schemas.MonitoringEventSubscription,
+)
 def delete_subscription(
     *,
-    scsAsId: str = Path(..., title="The ID of the Netapp that creates a subscription", example="myNetapp"),
+    scsAsId: str = Path(
+        ...,
+        title="The ID of the Netapp that creates a subscription",
+        example="myNetapp",
+    ),
     subscriptionId: str = Path(..., title="Identifier of the subscription resource"),
     current_user: models.User = Depends(deps.get_current_active_user),
-    http_request: Request
+    http_request: Request,
 ) -> Any:
     """
     Delete a subscription
     """
     db_mongo = client.fastapi
-    
+
     try:
         retrieved_doc = crud_mongo.read_uuid(db_mongo, db_collection, subscriptionId)
     except Exception as ex:
-        raise HTTPException(status_code=400, detail='Please enter a valid uuid (24-character hex string)')
-    
-    #Check if the document exists
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a valid uuid (24-character hex string)",
+        )
+
+    # Check if the document exists
     if not retrieved_doc:
         raise HTTPException(status_code=404, detail="Subscription not found")
-    #If the document exists then validate the owner
-    if not user.is_superuser(current_user) and (retrieved_doc['owner_id'] != current_user.id):
+    # If the document exists then validate the owner
+    if not user.is_superuser(current_user) and (
+        retrieved_doc["owner_id"] != current_user.id
+    ):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
     crud_mongo.delete_by_uuid(db_mongo, db_collection, subscriptionId)
@@ -279,6 +397,3 @@ def delete_subscription(
     http_response = JSONResponse(content=retrieved_doc, status_code=200)
     add_notifications(http_request, http_response, False)
     return http_response
-    
-    
-    

--- a/backend/app/app/api/api_v1/endpoints/monitoringevent.py
+++ b/backend/app/app/api/api_v1/endpoints/monitoringevent.py
@@ -11,6 +11,11 @@ from app.api.api_v1.endpoints.utils import add_notifications
 from app.crud import crud_mongo, ue, user
 from app.db.session import client
 from app.schemas.monitoringevent import MonitoringType
+from ue_movement import (
+    handle_location_report_callback,
+    handle_ue_reachability_callback,
+    handle_loss_connectivity_callback,
+)
 
 from .utils import ReportLogging
 
@@ -60,8 +65,8 @@ def read_active_subscriptions(
         http_response = JSONResponse(content=retrieved_docs, status_code=200)
         add_notifications(http_request, http_response, False)
         return http_response
-    else:
-        return Response(status_code=204)
+
+    return Response(status_code=204)
 
 
 # Callback
@@ -111,12 +116,11 @@ def create_subscription(
     # Because item_in puts default values to externalId and msisdn, even if none are specified.
     # Therefore we need to check if we already have the UE
     if not UE and item_in.msisdn:
-        print("searching for msisdn")
         UE = ue.get_supi(db=db, supi=item_in.msisdn)
 
     if not UE:
         raise HTTPException(
-            status_code=409, detail="UE with this external identifier doesn't exist"
+            status_code=404, detail="UE with this external identifier doesn't exist"
         )
 
     isByMaxReports = item_in.maximumNumberOfReports
@@ -130,118 +134,140 @@ def create_subscription(
         )
 
     # One time request
-    if (
-        item_in.monitoringType == MonitoringType.LOCATION_REPORTING
-        and item_in.maximumNumberOfReports == 1
-    ):
+    if item_in.maximumNumberOfReports == 1:
+        if item_in.monitoringType == MonitoringType.LOCATION_REPORTING:
 
-        json_compatible_item_data = {}
-        json_compatible_item_data["monitoringType"] = item_in.monitoringType
-        json_compatible_item_data["externalId"] = item_in.externalId
-        json_compatible_item_data["ipv4Addr"] = UE.ip_address_v4
+            json_compatible_item_data = {}
+            json_compatible_item_data["monitoringType"] = item_in.monitoringType
+            json_compatible_item_data["externalId"] = item_in.externalId
+            json_compatible_item_data["ipv4Addr"] = UE.ip_address_v4
 
-        if UE.Cell:
-            json_compatible_item_data["locationInfo"] = {
-                "cellId": UE.Cell.cell_id,
-                "gNBId": UE.Cell.gNB.gNB_id,
-            }
-        else:
-            json_compatible_item_data["locationInfo"] = {"cellId": None, "gNBId": None}
-
-        http_response = JSONResponse(content=json_compatible_item_data, status_code=200)
-        add_notifications(http_request, http_response, False)
-
-        return http_response
-    # Subscription
-
-    elif item_in.monitoringType == MonitoringType.LOCATION_REPORTING and (
-        isByMaxReports or isByExpireTime
-    ):
-
-        json_data = jsonable_encoder(item_in.dict(exclude_unset=True))
-        json_data.update({"owner_id": current_user.id, "ipv4Addr": UE.ip_address_v4})
-
-        inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
-
-        # Create the reference resource and location header
-        link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
-        response_header = {"location": link}
-
-        # Update the subscription with the new resource (link) and return the response (+response header)
-        crud_mongo.update_new_field(
-            db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
-        )
-
-        # Retrieve the updated document | UpdateResult is not a dict
-        updated_doc = crud_mongo.read_uuid(
-            db_mongo, db_collection, inserted_doc.inserted_id
-        )
-        updated_doc.pop("owner_id")
-
-        http_response = JSONResponse(
-            content=updated_doc, status_code=201, headers=response_header
-        )
-        add_notifications(http_request, http_response, False)
-
-        return http_response
-    elif (
-        item_in.monitoringType == MonitoringType.LOSS_OF_CONNECTIVITY
-        or item_in.monitoringType == MonitoringType.UE_REACHABILITY
-    ) and item_in.maximumNumberOfReports == 1:
-        return JSONResponse(
-            content=jsonable_encoder(
-                {
-                    "title": "The requested parameters are out of range",
-                    "invalidParams": {
-                        "param": "maximumNumberOfReports",
-                        "reason": '"maximumNumberOfReports" should be greater than 1 in case of LOSS_OF_CONNECTIVITY event',
-                    },
+            if UE.Cell:
+                json_compatible_item_data["locationInfo"] = {
+                    "cellId": UE.Cell.cell_id,
+                    "gNBId": UE.Cell.gNB.gNB_id,
                 }
-            ),
-            status_code=403,
-        )
-    elif (
-        item_in.monitoringType == MonitoringType.LOSS_OF_CONNECTIVITY
-        or item_in.monitoringType == MonitoringType.UE_REACHABILITY
-    ) and (isByMaxReports or isByExpireTime):
-        # Check if subscription with externalid && monitoringType exists
-        if crud_mongo.read_by_multiple_pairs(
-            db_mongo,
-            db_collection,
-            externalId=item_in.externalId,
-            monitoringType=item_in.monitoringType,
+            else:
+                json_compatible_item_data["locationInfo"] = {
+                    "cellId": None,
+                    "gNBId": None,
+                }
+
+            http_response = JSONResponse(
+                content=json_compatible_item_data, status_code=200
+            )
+            add_notifications(http_request, http_response, False)
+
+            return http_response
+
+        if (
+            item_in.monitoringType == MonitoringType.LOSS_OF_CONNECTIVITY
+            or item_in.monitoringType == MonitoringType.UE_REACHABILITY
         ):
-            raise HTTPException(
-                status_code=409,
-                detail=f"There is already an active subscription for UE with external id {item_in.externalId} - Monitoring Type = {item_in.monitoringType}",
+            return JSONResponse(
+                content=jsonable_encoder(
+                    {
+                        "title": "The requested parameters are out of range",
+                        "invalidParams": {
+                            "param": "maximumNumberOfReports",
+                            "reason": '"maximumNumberOfReports" should be greater than 1 in case of LOSS_OF_CONNECTIVITY event',
+                        },
+                    }
+                ),
+                status_code=403,
             )
 
-        json_data = jsonable_encoder(item_in.dict(exclude_unset=True))
-        json_data.update({"owner_id": current_user.id, "ipv4Addr": UE.ip_address_v4})
+    # Subscription
+    elif isByMaxReports or isByExpireTime:
+        if item_in.monitoringType == MonitoringType.LOCATION_REPORTING:
 
-        inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
+            json_data = jsonable_encoder(item_in.dict(exclude_unset=True))
+            json_data.update(
+                {"owner_id": current_user.id, "ipv4Addr": UE.ip_address_v4}
+            )
 
-        # Create the reference resource and location header
-        link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
-        response_header = {"location": link}
+            inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
 
-        # Update the subscription with the new resource (link) and return the response (+response header)
-        crud_mongo.update_new_field(
-            db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
-        )
+            if item_in.immediateRep:
+                handle_location_report_callback(inserted_doc, UE)
 
-        # Retrieve the updated document | UpdateResult is not a dict
-        updated_doc = crud_mongo.read_uuid(
-            db_mongo, db_collection, inserted_doc.inserted_id
-        )
-        updated_doc.pop("owner_id")
+            # Create the reference resource and location header
+            link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
+            response_header = {"location": link}
 
-        http_response = JSONResponse(
-            content=updated_doc, status_code=201, headers=response_header
-        )
-        add_notifications(http_request, http_response, False)
+            # Update the subscription with the new resource (link) and return the response (+response header)
+            crud_mongo.update_new_field(
+                db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
+            )
 
-        return http_response
+            # Retrieve the updated document | UpdateResult is not a dict
+            updated_doc = crud_mongo.read_uuid(
+                db_mongo, db_collection, inserted_doc.inserted_id
+            )
+            updated_doc.pop("owner_id")
+
+            http_response = JSONResponse(
+                content=updated_doc, status_code=201, headers=response_header
+            )
+            add_notifications(http_request, http_response, False)
+
+            return http_response
+        if (
+            item_in.monitoringType == MonitoringType.LOSS_OF_CONNECTIVITY
+            or item_in.monitoringType == MonitoringType.UE_REACHABILITY
+        ):
+            # Check if subscription with externalid && monitoringType exists
+            if crud_mongo.read_by_multiple_pairs(
+                db_mongo,
+                db_collection,
+                externalId=item_in.externalId,
+                monitoringType=item_in.monitoringType,
+            ):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"There is already an active subscription for UE with external id {item_in.externalId} - Monitoring Type = {item_in.monitoringType}",
+                )
+
+            json_data = jsonable_encoder(item_in.dict(exclude_unset=True))
+            json_data.update(
+                {"owner_id": current_user.id, "ipv4Addr": UE.ip_address_v4}
+            )
+
+            inserted_doc = crud_mongo.create(db_mongo, db_collection, json_data)
+
+            if (
+                item_in.immediateRep
+                and item_in.monitoringType == MonitoringType.LOSS_OF_CONNECTIVITY
+            ):
+                handle_loss_connectivity_callback(inserted_doc, UE)
+
+            elif (
+                item_in.immediateRep
+                and item_in.monitoringType == MonitoringType.UE_REACHABILITY
+            ):
+                handle_ue_reachability_callback(inserted_doc, UE)
+
+            # Create the reference resource and location header
+            link = str(http_request.url) + "/" + str(inserted_doc.inserted_id)
+            response_header = {"location": link}
+
+            # Update the subscription with the new resource (link) and return the response (+response header)
+            crud_mongo.update_new_field(
+                db_mongo, db_collection, inserted_doc.inserted_id, {"link": link}
+            )
+
+            # Retrieve the updated document | UpdateResult is not a dict
+            updated_doc = crud_mongo.read_uuid(
+                db_mongo, db_collection, inserted_doc.inserted_id
+            )
+            updated_doc.pop("owner_id")
+
+            http_response = JSONResponse(
+                content=updated_doc, status_code=201, headers=response_header
+            )
+            add_notifications(http_request, http_response, False)
+
+            return http_response
 
 
 @router.put(

--- a/backend/app/app/api/api_v1/endpoints/monitoringevent.py
+++ b/backend/app/app/api/api_v1/endpoints/monitoringevent.py
@@ -1,25 +1,26 @@
 from typing import Any, List
 
+from bson.objectid import ObjectId
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from sqlalchemy.orm import Session
-from bson.objectid import ObjectId
 from pydantic import parse_obj_as
+from sqlalchemy.orm import Session
 
 from app import models, schemas, tools
 from app.api import deps
 from app.api.api_v1.endpoints.utils import add_notifications
-from app.crud import crud_mongo, ue, user
+from app.crud import crud_mongo
+from app.crud import ue as crud_ue
+from app.crud import user
 from app.db.session import client
+from app.schemas.commonData import Link
 from app.schemas.monitoringevent import (
     GeographicalCoordinates,
+    LocationArea,
     MonitoringType,
     Point,
-    LocationArea,
 )
-from app.schemas.commonData import Link
-from app.crud import crud_mongo, ue as crud_ue, user
 
 from .ue_movement import (
     handle_location_report_callback,

--- a/backend/app/app/api/api_v1/endpoints/monitoringevent.py
+++ b/backend/app/app/api/api_v1/endpoints/monitoringevent.py
@@ -6,6 +6,8 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import parse_obj_as
 from sqlalchemy.orm import Session
+from bson.objectid import ObjectId
+from pydantic import parse_obj_as
 
 from app import models, schemas, tools
 from app.api import deps
@@ -21,6 +23,8 @@ from app.schemas.monitoringevent import (
     MonitoringType,
     Point,
 )
+from app.schemas.commonData import Link
+from app.crud import crud_mongo, ue as crud_ue, user
 
 from .ue_movement import (
     handle_location_report_callback,
@@ -133,16 +137,18 @@ def create_subscription(
     item_in.self = parse_obj_as(Link, f"{http_request.url}/{id}")
 
     if item_in.ipv4Addr is not None:
-        id_value = str(item_in.ueIpv4Addr)
+        print("The IPv4 Addr is", str(item_in.ipv4Addr))
+        id_value = str(item_in.ipv4Addr)
         ue = crud_ue.get_ipv4(db=db, ipv4=id_value, owner_id=current_user.id)
 
     elif item_in.ipv6Addr is not None:
-        id_value = item_in.ueIpv6Addr.exploded
+        print("The IPv6 Addr is", item_in.ipv6Addr.exploded)
+        id_value = item_in.ipv6Addr.exploded
         ue = crud_ue.get_ipv6(db=db, ipv6=id_value, owner_id=current_user.id)
 
     elif item_in.externalId:
         ue = crud_ue.get_externalId(
-            db=db, externalId=item_in.externalId, owner_id=current_user.id
+            db=db, externalId=item_in.externalId.__root__, owner_id=current_user.id
         )
 
     elif item_in.msisdn:

--- a/backend/app/app/api/api_v1/endpoints/monitoringevent.py
+++ b/backend/app/app/api/api_v1/endpoints/monitoringevent.py
@@ -11,6 +11,11 @@ from app.api.api_v1.endpoints.utils import add_notifications
 from app.crud import crud_mongo, ue, user
 from app.db.session import client
 from app.schemas.monitoringevent import MonitoringType
+from ue_movement import (
+    handle_location_report_callback,
+    handle_ue_reachability_callback,
+    handle_loss_connectivity_callback,
+)
 
 from .ue_movement import (
     handle_location_report_callback,

--- a/backend/app/app/api/api_v1/endpoints/tests.py
+++ b/backend/app/app/api/api_v1/endpoints/tests.py
@@ -22,15 +22,17 @@ def read_UE_serving_cell(*,
     if not crud.user.is_superuser(current_user) and (UE.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
-    if retrieve_ue(supi) == None:
+    ue = retrieve_ue(supi)
+    if ue is None:
         raise HTTPException(status_code=400, detail="The emulation needs to be ongoing")
 
     log = {
-        "latitude":retrieve_ue(supi)["latitude"],
-        "longitude": retrieve_ue(supi)["longitude"],
-        "UE_id": retrieve_ue(supi)["name"],
-        "S-PCI": retrieve_ue(supi)["Cell_id"]
+        "latitude": ue.latitude,
+        "longitude": ue.longitude,
+        "UE_id": ue.name,
+        "S-PCI": ue.Cell_id,
     }
+
     return log
 
 
@@ -50,7 +52,7 @@ def read_UE_distances(*,
     if retrieve_ue(supi) == None:
         raise HTTPException(status_code=400, detail="The emulation needs to be ongoing")
 
-    return retrieve_ue_distances(supi)
+    return retrieve_ue_distances(supi, current_user.id)
 
 
 @router.get("/{supi}/path_losses")
@@ -69,7 +71,7 @@ def read_UE_losses(*,
     if retrieve_ue(supi) == None:
         raise HTTPException(status_code=400, detail="The emulation needs to be ongoing")
 
-    return retrieve_ue_path_losses(supi)
+    return retrieve_ue_path_losses(supi, current_user.id)
 
 
 @router.get("/{supi}/rsrps")
@@ -88,7 +90,8 @@ def read_UE_rsrps(*,
     if retrieve_ue(supi) == None:
         raise HTTPException(status_code=400, detail="The emulation needs to be ongoing")
 
-    return retrieve_ue_rsrps(supi)
+    return retrieve_ue_rsrps(supi, current_user.id)
+
 
 @router.get("/{supi}/handovers")
 def read_UE_handovers(*,

--- a/backend/app/app/api/api_v1/endpoints/tests.py
+++ b/backend/app/app/api/api_v1/endpoints/tests.py
@@ -3,17 +3,24 @@ from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlalchemy.orm import Session
 from app import crud, models
 from app.api import deps
-from app.api.api_v1.endpoints.ue_movement import retrieve_ue, retrieve_ue_distances, retrieve_ue_path_losses, retrieve_ue_rsrps, retrieve_ue_handovers
+from app.api.api_v1.endpoints.ue_movement import (
+    retrieve_ue,
+    retrieve_ue_distances,
+    retrieve_ue_path_losses,
+    retrieve_ue_rsrps,
+    retrieve_ue_handovers,
+)
 from .utils import ReportLogging
 
 router = APIRouter()
 router.route_class = ReportLogging
 
+
 @router.get("/{supi}/serving_cell")
-def read_UE_serving_cell(*,
+def read_UE_serving_cell(
+    *,
     db: Session = Depends(deps.get_db),
-    supi: str = Path(...,
-                     description="The SUPI of the UE you want to retrieve"),
+    supi: str = Path(..., description="The SUPI of the UE you want to retrieve"),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     UE = crud.ue.get_supi(db=db, supi=supi)
@@ -37,10 +44,10 @@ def read_UE_serving_cell(*,
 
 
 @router.get("/{supi}/distances")
-def read_UE_distances(*,
+def read_UE_distances(
+    *,
     db: Session = Depends(deps.get_db),
-    supi: str = Path(...,
-                     description="The SUPI of the UE you want to retrieve"),
+    supi: str = Path(..., description="The SUPI of the UE you want to retrieve"),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     UE = crud.ue.get_supi(db=db, supi=supi)
@@ -56,10 +63,10 @@ def read_UE_distances(*,
 
 
 @router.get("/{supi}/path_losses")
-def read_UE_losses(*,
+def read_UE_losses(
+    *,
     db: Session = Depends(deps.get_db),
-    supi: str = Path(...,
-                     description="The SUPI of the UE you want to retrieve"),
+    supi: str = Path(..., description="The SUPI of the UE you want to retrieve"),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     UE = crud.ue.get_supi(db=db, supi=supi)
@@ -75,10 +82,10 @@ def read_UE_losses(*,
 
 
 @router.get("/{supi}/rsrps")
-def read_UE_rsrps(*,
+def read_UE_rsrps(
+    *,
     db: Session = Depends(deps.get_db),
-    supi: str = Path(...,
-                     description="The SUPI of the UE you want to retrieve"),
+    supi: str = Path(..., description="The SUPI of the UE you want to retrieve"),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     UE = crud.ue.get_supi(db=db, supi=supi)
@@ -86,7 +93,7 @@ def read_UE_rsrps(*,
         raise HTTPException(status_code=404, detail="UE not found")
     if not crud.user.is_superuser(current_user) and (UE.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
-    
+
     if retrieve_ue(supi) == None:
         raise HTTPException(status_code=400, detail="The emulation needs to be ongoing")
 
@@ -94,13 +101,14 @@ def read_UE_rsrps(*,
 
 
 @router.get("/{supi}/handovers")
-def read_UE_handovers(*,
+def read_UE_handovers(
+    *,
     db: Session = Depends(deps.get_db),
-    supi: str = Path(...,
-                     description="The SUPI of the UE you want to retrieve"),
+    supi: str = Path(..., description="The SUPI of the UE you want to retrieve"),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     UE = crud.ue.get_supi(db=db, supi=supi)
+    print(UE)
     if not UE:
         raise HTTPException(status_code=404, detail="UE not found")
     if not crud.user.is_superuser(current_user) and (UE.owner_id != current_user.id):
@@ -108,5 +116,5 @@ def read_UE_handovers(*,
 
     if retrieve_ue(supi) == None:
         raise HTTPException(status_code=400, detail="The emulation needs to be ongoing")
-        
+
     return retrieve_ue_handovers(supi)

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -3,6 +3,9 @@ from app.models.UE import UE
 from fastapi import APIRouter, Path, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from typing import Any, Literal, Optional
+from fastapi import APIRouter, Path, Depends, HTTPException, BackgroundTasks
+from fastapi.encoders import jsonable_encoder
+from typing import Any
 from app import crud, tools, models
 from app.crud import crud_mongo
 from app.tools.distance import check_distance
@@ -26,13 +29,6 @@ from app.schemas.monitoringevent import (
 )
 from app.schemas.afSessionWithQos import AsSessionWithQoSSubscription
 from app.tools import monitoring_callbacks, timer
-
-from app.core.notification_responder import notification_responder
-
-from app.tools import monitoring_callbacks, qos_callback, timer
-from app.tools.distance import check_distance
-from app.tools.rsrp_calculation import check_path_loss, check_rsrp
-from fastapi import BackgroundTasks
 
 # Dictionary holding threads that are running per user id.
 threads = {}
@@ -371,7 +367,142 @@ def movement_loop(supi: str, user: models.User):
 
 
 def location_notification(ue: UE):
+    db_mongo = client.fastapi
+    subscriptions = crud_mongo.read_all_by_multiple_pairs(
+        db_mongo,
+        "MonitoringEvent",
+        externalId=ue.external_identifier,
+    )
+
+    for sub in subscriptions:
+        sub_validate_time = tools.check_expiration_time(
+            expire_time=sub.get("monitorExpireTime")
+        )
+
+        sub_validate_number_of_reports = tools.check_numberOfReports(
+            sub.get("maximumNumberOfReports")
+        )
+
+        if not sub_validate_time or not sub_validate_number_of_reports:
+            crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", sub.get("_id"))
+            continue
+
+        if sub.monitoringType == "LOCATION_REPORTING":
+            handle_location_report_callback(sub, ue)
+
+        elif sub.monitoringType == "LOSS_OF_CONNECTIVITY":
+            handle_loss_connectivity_callback(sub, ue)
+
+        elif sub.monitoringType == "UE_REACHABILITY":
+            handle_ue_reachability_callback(sub, ue)
+
+
+def handle_location_report_callback(ue_reachability_sub, ue: UE):
+    db_mongo = client.fastapi
+    try:
+        monitoring_callbacks.ue_reachability_callback(
+            ue,
+            ue_reachability_sub.get("notificationDestination"),
+            ue_reachability_sub.get("link"),
+            ue_reachability_sub.get("reachabilityType"),
+        )
+
+        if ue_reachability_sub.maximumNumberOfReports:
+            ue_reachability_sub.update(
+                {
+                    "maximumNumberOfReports": ue_reachability_sub.get(
+                        "maximumNumberOfReports"
+                    )
+                    - 1
+                }
+            )
+
+            crud_mongo.update(
+                db_mongo,
+                "MonitoringEvent",
+                ue_reachability_sub.get("_id"),
+                ue_reachability_sub,
+            )
+
+    except requests.exceptions.ConnectionError as ex:
+        logging.warning(f"Failed to send the callback request with error {ex}")
+        crud_mongo.delete_by_uuid(
+            db_mongo,
+            "MonitoringEvent",
+            ue_reachability_sub.get("_id"),
+        )
+
+
+def handle_loss_connectivity_callback(loss_of_connectivity_sub, ue: UE):
+    db_mongo = client.fastapi
+    try:
+        elapsed_time = t.status()
+        if elapsed_time > loss_of_connectivity_sub.get("maximumDetectionTime"):
+            response = monitoring_callbacks.loss_of_connectivity_callback(
+                ue,
+                loss_of_connectivity_sub.get("notificationDestination"),
+                loss_of_connectivity_sub.get("link"),
+            )
+
+            logging.critical(response.json())
+            # This ack is used to send one time the loss of connectivity callback
+            loss_of_connectivity_ack = response.json().get("ack")
+
+            loss_of_connectivity_sub.update(
+                {
+                    "maximumNumberOfReports": loss_of_connectivity_sub.get(
+                        "maximumNumberOfReports"
+                    )
+                    - 1
+                }
+            )
+            crud_mongo.update(
+                db_mongo,
+                "MonitoringEvent",
+                loss_of_connectivity_sub.get("_id"),
+                loss_of_connectivity_sub,
+            )
+    except requests.exceptions.ConnectionError as ex:
+        logging.warning("Failed to send the callback request")
+        logging.warning(ex)
+        crud_mongo.delete_by_uuid(
+            db_mongo,
+            "MonitoringEvent",
+            loss_of_connectivity_sub.get("_id"),
+        )
+
+
+def handle_ue_reachability_callback(subscription, ue: UE):
     pass
+
+
+@router.post("/update_location/{supi}", status_code=200)
+def update_location(
+    *,
+    supi: str = Path(...),
+    new_location: Point,
+    background_tasks: BackgroundTasks,
+    current_user: models.User = Depends(deps.get_current_active_user),
+):
+    db = SessionLocal()
+    ue = crud.ue.get_supi(db, supi)
+
+    if not ue:
+        raise HTTPException(
+            status_code=404,
+            detail="No device found",
+        )
+
+    crud.ue.update_coordinates(
+        db,
+        lat=new_location.point.lat,
+        long=new_location.point.lon,
+        db_obj=ue,
+    )
+
+    # TODO: Send notifications related to location update
+
+    return {"msg": "Location updated"}
 
 
 @router.post("/start-loop", status_code=200)

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -39,514 +39,6 @@ rsrps = {}
 
 handovers = {}
 
-# connection = pika.BlockingConnection(pika.ConnectionParameters('rabbitmq'))
-# channel = connection.channel()
-# channel.queue_declare(queue='my_queue')
-
-
-class BackgroundTask(threading.Thread):
-
-    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None):
-        super().__init__(group=group, target=target, name=name)
-        self._args = args
-        self._kwargs = kwargs
-        self._stop_threads = False
-        self._db = SessionLocal()
-        return
-
-    def run(self):
-
-        current_user = self._args[0]
-        supi = self._args[1]
-
-        active_subscriptions = {
-            "location_reporting": False,
-            "ue_reachability": False,
-            "loss_of_connectivity": False,
-            "as_session_with_qos": False,
-        }
-
-        try:
-            db_mongo = client.fastapi
-
-            UE = crud.ue.get_supi(db=self._db, supi=supi)
-            if not UE:
-                logging.warning("UE not found")
-                threads.pop(f"{supi}")
-                return
-            if UE.owner_id != current_user.id:
-                logging.warning("Not enough permissions")
-                threads.pop(f"{supi}")
-                return
-
-            # Insert running UE in the dictionary
-
-            global ues, distances, handovers
-            ues[f"{supi}"] = jsonable_encoder(UE)
-            ues[f"{supi}"].pop("id")
-
-            if UE.Cell_id != None:
-                ues[f"{supi}"]["cell_id_hex"] = UE.Cell.cell_id
-                ues[f"{supi}"]["gnb_id_hex"] = UE.Cell.gNB.gNB_id
-            else:
-                ues[f"{supi}"]["cell_id_hex"] = None
-                ues[f"{supi}"]["gnb_id_hex"] = None
-
-            # Retrieve paths & points
-            path = crud.path.get(db=self._db, id=UE.path_id)
-            if not path:
-                logging.warning("Path not found")
-                threads.pop(f"{supi}")
-                return
-            if path.owner_id != current_user.id:
-                logging.warning("Not enough permissions")
-                threads.pop(f"{supi}")
-                return
-
-            points = crud.points.get_points(db=self._db, path_id=UE.path_id)
-            points = jsonable_encoder(points)
-
-            # Retrieve all the cells
-            Cells = crud.cell.get_multi_by_owner(
-                db=self._db, owner_id=current_user.id, skip=0, limit=100
-            )
-            json_cells = jsonable_encoder(Cells)
-
-            is_superuser = crud.user.is_superuser(current_user)
-
-            t = timer.SequencialTimer(logger=logging.critical)
-            rt = None
-            # global loss_of_connectivity_ack
-            loss_of_connectivity_ack = "FALSE"
-            """
-            ===================================================================
-                               2nd Approach for updating UEs position
-            ===================================================================
-
-            Summary: while(TRUE) --> keep increasing the moving index
-
-
-                points [ 1 2 3 4 5 6 7 8 9 10 ... ] . . . . . . .
-                         ^ current index
-                         ^  moving index                ^ moving can also reach here
-                 
-            current: shows where the UE is
-            moving : starts within the range of len(points) and keeps increasing.
-                     When it goes out of these bounds, the MOD( len(points) ) prevents
-                     the "index out of range" exception. It also starts the iteration
-                     of points from the begining, letting the UE moving in endless loops.
-
-            Sleep:   in both LOW / HIGH speed cases, the thread sleeps for 1 sec
-
-            Speed:   LOW : (moving_position_index += 1)  no points are skipped, this means 1m/sec
-                     HIGH: (moving_position_index += 10) skips 10 points, thus...        ~10m/sec
-
-            Pros:    + the UE position is updated once every sec (not very aggressive)
-                     + we can easily set speed this way (by skipping X points --> X m/sec)
-            Cons:    - skipping points and updating once every second decreases the event resolution
-
-            -------------------------------------------------------------------
-            """
-
-            current_position_index = -1
-
-            # find the index of the point where the UE is located
-            for index, point in enumerate(points):
-                if (UE.latitude == point["latitude"]) and (
-                    UE.longitude == point["longitude"]
-                ):
-                    current_position_index = index
-
-            # start iterating from this index and keep increasing the moving_position_index...
-            moving_position_index = current_position_index
-
-            while True:
-                try:
-                    crud.ue.update_coordinates(
-                        db=self._db,
-                        lat=ues[f"{supi}"]["latitude"],
-                        long=ues[f"{supi}"]["longitude"],
-                        db_obj=UE,
-                    )
-                    # cell_now = check_distance(UE.latitude, UE.longitude, json_cells) #calculate the distance from all the cells
-                    ues[f"{supi}"]["latitude"] = points[current_position_index][
-                        "latitude"
-                    ]
-                    ues[f"{supi}"]["longitude"] = points[current_position_index][
-                        "longitude"
-                    ]
-                    cell_now, distances_now = check_distance(
-                        ues[f"{supi}"]["latitude"],
-                        ues[f"{supi}"]["longitude"],
-                        json_cells,
-                    )  # calculate the distance from all the cells
-                    distances[f"{supi}"] = distances_now
-                    path_losses_now = check_path_loss(
-                        ues[f"{supi}"]["latitude"],
-                        ues[f"{supi}"]["longitude"],
-                        json_cells,
-                    )
-                    path_losses[f"{supi}"] = path_losses_now
-                    rsrp_now = check_rsrp(
-                        ues[f"{supi}"]["latitude"],
-                        ues[f"{supi}"]["longitude"],
-                        json_cells,
-                    )
-                    rsrps[f"{supi}"] = rsrp_now
-
-                except Exception as ex:
-                    logging.warning("Failed to update coordinates")
-                    logging.warning(ex)
-
-                # MonitoringEvent API - Loss of connectivity
-                if not active_subscriptions.get("loss_of_connectivity"):
-                    loss_of_connectivity_sub = crud_mongo.read_by_multiple_pairs(
-                        db_mongo,
-                        "MonitoringEvent",
-                        externalId=UE.external_identifier,
-                        monitoringType="LOSS_OF_CONNECTIVITY",
-                    )
-                    if loss_of_connectivity_sub:
-                        active_subscriptions.update({"loss_of_connectivity": True})
-
-                # Validation of subscription
-                if (
-                    active_subscriptions.get("loss_of_connectivity")
-                    and loss_of_connectivity_ack == "FALSE"
-                ):
-                    sub_is_valid = monitoring_event_sub_validation(
-                        loss_of_connectivity_sub,
-                        is_superuser,
-                        current_user.id,
-                        loss_of_connectivity_sub.get("owner_id"),
-                    )
-                    if sub_is_valid:
-                        try:
-                            try:
-                                elapsed_time = t.status()
-                                if elapsed_time > loss_of_connectivity_sub.get(
-                                    "maximumDetectionTime"
-                                ):
-                                    response = monitoring_callbacks.loss_of_connectivity_callback(
-                                        ues[f"{supi}"],
-                                        loss_of_connectivity_sub.get(
-                                            "notificationDestination"
-                                        ),
-                                        loss_of_connectivity_sub.get("link"),
-                                    )
-
-                                    logging.critical(response.json())
-                                    # This ack is used to send one time the loss of connectivity callback
-                                    loss_of_connectivity_ack = response.json().get(
-                                        "ack"
-                                    )
-
-                                    loss_of_connectivity_sub.update(
-                                        {
-                                            "maximumNumberOfReports": loss_of_connectivity_sub.get(
-                                                "maximumNumberOfReports"
-                                            )
-                                            - 1
-                                        }
-                                    )
-                                    crud_mongo.update(
-                                        db_mongo,
-                                        "MonitoringEvent",
-                                        loss_of_connectivity_sub.get("_id"),
-                                        loss_of_connectivity_sub,
-                                    )
-                            except timer.TimerError as ex:
-                                # logging.critical(ex)
-                                pass
-                        except requests.exceptions.ConnectionError as ex:
-                            logging.warning("Failed to send the callback request")
-                            logging.warning(ex)
-                            crud_mongo.delete_by_uuid(
-                                db_mongo,
-                                "MonitoringEvent",
-                                loss_of_connectivity_sub.get("_id"),
-                            )
-                            continue
-                    else:
-                        crud_mongo.delete_by_uuid(
-                            db_mongo,
-                            "MonitoringEvent",
-                            loss_of_connectivity_sub.get("_id"),
-                        )
-                        active_subscriptions.update({"loss_of_connectivity": False})
-                        logging.warning("Subscription has expired")
-                # MonitoringEvent API - Loss of connectivity
-
-                # As Session With QoS API - search for active subscription in db
-                if not active_subscriptions.get("as_session_with_qos"):
-                    qos_sub = crud_mongo.read(
-                        db_mongo, "QoSMonitoring", "ipv4Addr", UE.ip_address_v4
-                    )
-                    if qos_sub:
-                        active_subscriptions.update({"as_session_with_qos": True})
-                        reporting_freq = qos_sub["qosMonInfo"]["repFreqs"]
-                        reporting_period = qos_sub["qosMonInfo"]["repPeriod"]
-                        if "PERIODIC" in reporting_freq:
-                            rt = timer.RepeatedTimer(
-                                reporting_period,
-                                qos_callback.qos_notification_control,
-                                qos_sub,
-                                ues[f"{supi}"]["ip_address_v4"],
-                                ues.copy(),
-                                ues[f"{supi}"],
-                            )
-                            # qos_callback.qos_notification_control(qos_sub, ues[f"{supi}"]["ip_address_v4"], ues.copy(),  ues[f"{supi}"])
-
-                # If the document exists then validate the owner
-                if not is_superuser and (qos_sub["owner_id"] != current_user.id):
-                    logging.warning("Not enough permissions")
-                    active_subscriptions.update({"as_session_with_qos": False})
-                # As Session With QoS API - search for active subscription in db
-
-                if cell_now != None:
-                    try:
-                        t.stop()
-                        loss_of_connectivity_ack = "FALSE"
-                        if rt is not None:
-                            rt.start()
-                    except timer.TimerError:
-                        # logging.critical(ex)
-                        pass
-
-                    # if UE.Cell_id != cell_now.get('id'): #Cell has changed in the db "handover"
-                    if ues[f"{supi}"]["Cell_id"] != cell_now.get(
-                        "id"
-                    ):  # Cell has changed in the db "handover"
-
-                        # Monitoring Event API - UE reachability
-                        # check if the ue was disconnected before
-                        if ues[f"{supi}"]["Cell_id"] == None:
-
-                            if not active_subscriptions.get("ue_reachability"):
-                                ue_reachability_sub = crud_mongo.read_by_multiple_pairs(
-                                    db_mongo,
-                                    "MonitoringEvent",
-                                    externalId=UE.external_identifier,
-                                    monitoringType="UE_REACHABILITY",
-                                )
-                                if ue_reachability_sub:
-                                    active_subscriptions.update(
-                                        {"ue_reachability": True}
-                                    )
-
-                            # Validation of subscription
-
-                            if active_subscriptions.get("ue_reachability"):
-                                sub_is_valid = monitoring_event_sub_validation(
-                                    ue_reachability_sub,
-                                    is_superuser,
-                                    current_user.id,
-                                    ue_reachability_sub.get("owner_id"),
-                                )
-                                if sub_is_valid:
-                                    try:
-                                        try:
-                                            monitoring_callbacks.ue_reachability_callback(
-                                                ues[f"{supi}"],
-                                                ue_reachability_sub.get(
-                                                    "notificationDestination"
-                                                ),
-                                                ue_reachability_sub.get("link"),
-                                                ue_reachability_sub.get(
-                                                    "reachabilityType"
-                                                ),
-                                            )
-                                            ue_reachability_sub.update(
-                                                {
-                                                    "maximumNumberOfReports": ue_reachability_sub.get(
-                                                        "maximumNumberOfReports"
-                                                    )
-                                                    - 1
-                                                }
-                                            )
-                                            crud_mongo.update(
-                                                db_mongo,
-                                                "MonitoringEvent",
-                                                ue_reachability_sub.get("_id"),
-                                                ue_reachability_sub,
-                                            )
-                                        except timer.TimerError as ex:
-                                            # logging.critical(ex)
-                                            pass
-                                    except requests.exceptions.ConnectionError as ex:
-                                        logging.warning(
-                                            "Failed to send the callback request"
-                                        )
-                                        logging.warning(ex)
-                                        crud_mongo.delete_by_uuid(
-                                            db_mongo,
-                                            "MonitoringEvent",
-                                            ue_reachability_sub.get("_id"),
-                                        )
-                                        active_subscriptions.update(
-                                            {"ue_reachability": False}
-                                        )
-                                        continue
-                                else:
-                                    crud_mongo.delete_by_uuid(
-                                        db_mongo,
-                                        "MonitoringEvent",
-                                        ue_reachability_sub.get("_id"),
-                                    )
-                                    active_subscriptions.update(
-                                        {"ue_reachability": False}
-                                    )
-                                    logging.warning("Subscription has expired")
-                        # Monitoring Event API - UE reachability
-
-                        logging.warning(
-                            f"UE({UE.supi}) with ipv4 {UE.ip_address_v4} handovers to Cell {cell_now.get('id')}, {cell_now.get('description')}"
-                        )
-
-                        if f"{UE.supi}" not in handovers.keys():
-                            handovers[f"{UE.supi}"] = []
-
-                        handovers[f"{UE.supi}"].append(cell_now.get("id"))
-
-                        ues[f"{supi}"]["Cell_id"] = cell_now.get("id")
-                        ues[f"{supi}"]["cell_id_hex"] = cell_now.get("cell_id")
-                        gnb = crud.gnb.get(db=self._db, id=cell_now.get("gNB_id"))
-                        ues[f"{supi}"]["gnb_id_hex"] = gnb.gNB_id
-
-                    # Monitoring Event API - Location Reporting
-                    # Retrieve the subscription of the UE by external Id | This could be outside while true but then the user cannot subscribe when the loop runs
-                    if not active_subscriptions.get("location_reporting"):
-                        location_reporting_sub = crud_mongo.read_by_multiple_pairs(
-                            db_mongo,
-                            "MonitoringEvent",
-                            externalId=UE.external_identifier,
-                            monitoringType="LOCATION_REPORTING",
-                        )
-                        if location_reporting_sub:
-                            active_subscriptions.update({"location_reporting": True})
-
-                    # Validation of subscription
-                    if active_subscriptions.get("location_reporting"):
-                        sub_is_valid = monitoring_event_sub_validation(
-                            location_reporting_sub,
-                            is_superuser,
-                            current_user.id,
-                            location_reporting_sub.get("owner_id"),
-                        )
-                        if sub_is_valid:
-                            try:
-                                try:
-                                    monitoring_callbacks.location_callback(
-                                        ues[f"{supi}"],
-                                        location_reporting_sub.get(
-                                            "notificationDestination"
-                                        ),
-                                        location_reporting_sub.get("link"),
-                                    )
-                                    location_reporting_sub.update(
-                                        {
-                                            "maximumNumberOfReports": location_reporting_sub.get(
-                                                "maximumNumberOfReports"
-                                            )
-                                            - 1
-                                        }
-                                    )
-                                    crud_mongo.update(
-                                        db_mongo,
-                                        "MonitoringEvent",
-                                        location_reporting_sub.get("_id"),
-                                        location_reporting_sub,
-                                    )
-                                except timer.TimerError as ex:
-                                    # logging.critical(ex)
-                                    pass
-                            except requests.exceptions.ConnectionError as ex:
-                                logging.warning("Failed to send the callback request")
-                                logging.warning(ex)
-                                crud_mongo.delete_by_uuid(
-                                    db_mongo,
-                                    "MonitoringEvent",
-                                    location_reporting_sub.get("_id"),
-                                )
-                                active_subscriptions.update(
-                                    {"location_reporting": False}
-                                )
-                                continue
-                        else:
-                            crud_mongo.delete_by_uuid(
-                                db_mongo,
-                                "MonitoringEvent",
-                                location_reporting_sub.get("_id"),
-                            )
-                            active_subscriptions.update({"location_reporting": False})
-                            logging.warning("Subscription has expired")
-                    # Monitoring Event API - Location Reporting
-
-                    # As Session With QoS API - if EVENT_TRIGGER then send callback on handover
-                    if active_subscriptions.get("as_session_with_qos"):
-                        reporting_freq = qos_sub.qosMonInfo.repFreqs
-                        if "EVENT_TRIGGERED" in reporting_freq:
-                            qos_callback.qos_notification_control(
-                                qos_sub,
-                                ues[f"{supi}"]["ip_address_v4"],
-                                ues.copy(),
-                                ues[f"{supi}"],
-                            )
-                    # As Session With QoS API - if EVENT_TRIGGER then send callback on handover
-
-                else:
-                    # crud.ue.update(db=db, db_obj=UE, obj_in={"Cell_id" : None})
-                    try:
-                        t.start()
-                        if rt is not None:
-                            rt.stop()
-                    except timer.TimerError:
-                        # logging.critical(ex)
-                        pass
-
-                    ues[f"{supi}"]["Cell_id"] = None
-                    ues[f"{supi}"]["cell_id_hex"] = None
-                    ues[f"{supi}"]["gnb_id_hex"] = None
-
-                # logging.info(f'User: {current_user.id} | UE: {supi} | Current location: latitude ={UE.latitude} | longitude = {UE.longitude} | Speed: {UE.speed}' )
-
-                if UE.speed == "LOW":
-                    # don't skip any points, keep default speed 1m /sec
-                    moving_position_index += 1
-                elif UE.speed == "HIGH":
-                    # skip 10 points --> 10m / sec
-                    moving_position_index += 10
-
-                time.sleep(1)
-
-                current_position_index = moving_position_index % (len(points))
-
-                if self._stop_threads:
-                    logging.critical("Terminating thread...")
-                    crud.ue.update_coordinates(
-                        db=self._db,
-                        lat=ues[f"{supi}"]["latitude"],
-                        long=ues[f"{supi}"]["longitude"],
-                        db_obj=UE,
-                    )
-                    crud.ue.update(
-                        db=self._db,
-                        db_obj=UE,
-                        obj_in={"Cell_id": ues[f"{supi}"]["Cell_id"]},
-                    )
-                    ues.pop(f"{supi}")
-                    self._db.close()
-                    if rt is not None:
-                        rt.stop()
-                    break
-
-        except Exception as ex:
-            logging.critical(ex)
-
-    def stop(self):
-        self._stop_threads = True
-
-
 # API
 router = APIRouter()
 
@@ -596,6 +88,7 @@ def movement_loop(supi: str, user: models.User):
 
     # Assume end of path
     current_position_index = -1
+    cells = jsonable_encoder(crud.cell.get_multi_by_owner(db=db, owner_id=user.id))
 
     # Find current position if one exists
     for index, point in enumerate(points):
@@ -610,9 +103,22 @@ def movement_loop(supi: str, user: models.User):
         current_position_index += increment_position(ue.speed) % len(points)
         point = points[current_position_index]
 
+        cell_now, cell_distances = check_distance(
+            point.latitude, point.longitude, cells
+        )
+
         ue = crud.ue.update_coordinates(
             db=db, lat=point.latitude, long=point.longitude, db_obj=ue
         )
+
+        logging.info("The current cell is %d", cell_now)
+        if cell_now and ue.Cell_id != cell_now.get("id"):
+            ue.Cell_id = cell_now.get("id")
+            crud.ue.update(
+                db=db,
+                db_obj=ue,
+                obj_in={"Cell_id": ue.Cell_id},
+            )
 
         location_notification(ue)
 
@@ -667,20 +173,17 @@ def handle_location_report_callback(location_reporting_sub, ue: UE):
             location_reporting_sub.get("notificationDestination"),
             location_reporting_sub.get("link"),
         )
-        location_reporting_sub.update(
-            {
-                "maximumNumberOfReports": location_reporting_sub.get(
-                    "maximumNumberOfReports"
-                )
-                - 1
-            }
-        )
-        crud_mongo.update(
-            db_mongo,
-            "MonitoringEvent",
-            location_reporting_sub.get("_id"),
-            location_reporting_sub,
-        )
+
+        maxReports = location_reporting_sub.get("maximumNumberOfReports")
+
+        if maxReports:
+            location_reporting_sub.update({"maximumNumberOfReports": maxReports - 1})
+            crud_mongo.update(
+                db_mongo,
+                "MonitoringEvent",
+                location_reporting_sub.get("_id"),
+                location_reporting_sub,
+            )
 
     except requests.exceptions.ConnectionError as ex:
         logging.warning("Failed to send the callback request with error %d", ex)
@@ -756,15 +259,13 @@ def terminate_movement(
     Stop the loop.
     """
     try:
-        threads[f"{msg.supi}"][f"{current_user.id}"].stop()
-        threads[f"{msg.supi}"][f"{current_user.id}"].join()
-        threads.pop(f"{msg.supi}")
+        moving_devices.pop(msg.supi)
         return {"msg": "Loop ended"}
     except KeyError as ke:
         print("Key Not Found in Threads Dictionary:", ke)
         raise HTTPException(
             status_code=409,
-            detail="There is no thread running for this user! Please initiate a new thread",
+            detail="There is no generator running for this SUPI",
         )
 
 
@@ -787,7 +288,7 @@ def state_ues(
     """
     Get the state
     """
-    return ues
+    return crud.ue.get_multi_by_owner(SessionLocal(), owner_id=current_user.id)
 
 
 # Functions
@@ -800,15 +301,22 @@ def retrieve_ue_state(supi: str, user_id: int) -> bool:
 
 
 def retrieve_ues() -> dict:
-    return ues
+    return crud.ue.get_multi_by_owner(SessionLocal(), owner_id=current_user.id)
 
 
 def retrieve_ue(supi: str) -> dict:
-    return ues.get(supi)
+    return crud.ue.get_supi(SessionLocal(), supi)
 
 
-def retrieve_ue_distances(supi: str) -> dict:
-    return distances.get(supi)
+def retrieve_ue_distances(supi: str, user_id: int) -> dict:
+    db = SessionLocal()
+    ue = crud.ue.get_supi(db, supi)
+    if ue is None:
+        return {}
+
+    cells = jsonable_encoder(crud.cell.get_multi_by_owner(db=db, owner_id=user_id))
+    _, distances = check_distance(ue.latitude, ue.longitude, cells)
+    return distances
 
 
 def retrieve_ue_path_losses(supi: str) -> dict:

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -133,7 +133,7 @@ async def movement_loop(supi: str, user: models.User):
             ue, ue.Cell_id, cell_now.get("id") if cell_now else None
         )
 
-        time.sleep(1)
+        await asyncio.sleep(1)
 
 
 async def location_notification(

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -1,12 +1,11 @@
 import threading, logging, time, requests
-<<<<<<< HEAD
 from app.models.UE import UE
 from fastapi import APIRouter, Path, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
 from typing import Any, Literal, Optional
 from fastapi import APIRouter, Path, Depends, HTTPException, BackgroundTasks
 from fastapi.encoders import jsonable_encoder
-from typing import Any 
+from typing import Any
 from app import crud, tools, models
 from app.crud import crud_mongo
 from app.tools.distance import check_distance
@@ -641,93 +640,58 @@ def location_notification(ue: UE):
             crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", sub.get("_id"))
             continue
 
-        if sub.monitoringType == "LOCATION_REPORTING":
+        monitoringType = sub["monitoringType"]
+
+        if monitoringType == "LOCATION_REPORTING":
             handle_location_report_callback(sub, ue)
 
-        elif sub.monitoringType == "LOSS_OF_CONNECTIVITY":
+        elif monitoringType == "LOSS_OF_CONNECTIVITY":
             handle_loss_connectivity_callback(sub, ue)
 
-        elif sub.monitoringType == "UE_REACHABILITY":
+        elif monitoringType == "UE_REACHABILITY":
             handle_ue_reachability_callback(sub, ue)
 
 
-def handle_location_report_callback(ue_reachability_sub, ue: UE):
+def handle_location_report_callback(location_reporting_sub, ue: UE):
     db_mongo = client.fastapi
     try:
-        monitoring_callbacks.ue_reachability_callback(
-            ue,
-            ue_reachability_sub.get("notificationDestination"),
-            ue_reachability_sub.get("link"),
-            ue_reachability_sub.get("reachabilityType"),
+        logging.info(
+            "Attempting to send the callback to %d",
+            location_reporting_sub.get("notificationDestination"),
         )
-
-        if ue_reachability_sub.maximumNumberOfReports:
-            ue_reachability_sub.update(
-                {
-                    "maximumNumberOfReports": ue_reachability_sub.get(
-                        "maximumNumberOfReports"
-                    )
-                    - 1
-                }
-            )
-
-            crud_mongo.update(
-                db_mongo,
-                "MonitoringEvent",
-                ue_reachability_sub.get("_id"),
-                ue_reachability_sub,
-            )
-
-    except requests.exceptions.ConnectionError as ex:
-        logging.warning(f"Failed to send the callback request with error {ex}")
-        crud_mongo.delete_by_uuid(
+        print(
+            f"Attempting to send the callback to {location_reporting_sub.get('notificationDestination')}"
+        )
+        monitoring_callbacks.location_callback(
+            jsonable_encoder(ue),
+            location_reporting_sub.get("notificationDestination"),
+            location_reporting_sub.get("link"),
+        )
+        location_reporting_sub.update(
+            {
+                "maximumNumberOfReports": location_reporting_sub.get(
+                    "maximumNumberOfReports"
+                )
+                - 1
+            }
+        )
+        crud_mongo.update(
             db_mongo,
             "MonitoringEvent",
-            ue_reachability_sub.get("_id"),
+            location_reporting_sub.get("_id"),
+            location_reporting_sub,
         )
+
+    except requests.exceptions.ConnectionError as ex:
+        logging.warning("Failed to send the callback request with error %d", ex)
 
 
 def handle_loss_connectivity_callback(loss_of_connectivity_sub, ue: UE):
-    db_mongo = client.fastapi
-    try:
-        elapsed_time = t.status()
-        if elapsed_time > loss_of_connectivity_sub.get("maximumDetectionTime"):
-            response = monitoring_callbacks.loss_of_connectivity_callback(
-                ue,
-                loss_of_connectivity_sub.get("notificationDestination"),
-                loss_of_connectivity_sub.get("link"),
-            )
-
-            logging.critical(response.json())
-            # This ack is used to send one time the loss of connectivity callback
-            loss_of_connectivity_ack = response.json().get("ack")
-
-            loss_of_connectivity_sub.update(
-                {
-                    "maximumNumberOfReports": loss_of_connectivity_sub.get(
-                        "maximumNumberOfReports"
-                    )
-                    - 1
-                }
-            )
-            crud_mongo.update(
-                db_mongo,
-                "MonitoringEvent",
-                loss_of_connectivity_sub.get("_id"),
-                loss_of_connectivity_sub,
-            )
-    except requests.exceptions.ConnectionError as ex:
-        logging.warning("Failed to send the callback request")
-        logging.warning(ex)
-        crud_mongo.delete_by_uuid(
-            db_mongo,
-            "MonitoringEvent",
-            loss_of_connectivity_sub.get("_id"),
-        )
+    logging.error("There was an attempt at calling the connectivity callback")
 
 
 def handle_ue_reachability_callback(subscription, ue: UE):
-    pass
+    logging.error("There was an attempt at calling the reachability callback")
 
 
 @router.post("/update_location/{supi}", status_code=200)
@@ -747,7 +711,7 @@ def update_location(
             detail="No device found",
         )
 
-    crud.ue.update_coordinates(
+    ue = crud.ue.update_coordinates(
         db,
         lat=new_location.point.lat,
         long=new_location.point.lon,
@@ -755,6 +719,7 @@ def update_location(
     )
 
     # TODO: Send notifications related to location update
+    background_tasks.add_task(location_notification, ue)
 
     return {"msg": "Location updated"}
 

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -1,4 +1,5 @@
-import logging, asyncio
+import asyncio
+import logging
 from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
@@ -6,23 +7,21 @@ from fastapi.encoders import jsonable_encoder
 
 from app import crud, models, tools
 from app.api import deps
+from app.core.notification_responder import notification_responder
 from app.crud import crud_mongo
 from app.db.session import SessionLocal, client
 from app.models.UE import UE
 from app.schemas import Msg
 from app.schemas.monitoringevent import (
+    GeographicalCoordinates,
+    LocationInfo,
     MonitoringEventReport,
     MonitoringNotification,
     MonitoringType,
-    LocationInfo,
     Point,
     ReachabilityType,
     SupportedGADShapes,
-    GeographicalCoordinates,
 )
-
-from app.core.notification_responder import notification_responder
-
 from app.tools.distance import check_distance
 
 # Dictionary holding threads that are running per user id.

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -1,26 +1,23 @@
-import threading, logging, time, requests
-from app.models.UE import UE
-from fastapi import APIRouter, Path, Depends, HTTPException
-from fastapi.encoders import jsonable_encoder
+import logging
+import threading
+import time
 from typing import Any, Literal, Optional
-from fastapi import APIRouter, Path, Depends, HTTPException, BackgroundTasks
+
+import requests
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
 from fastapi.encoders import jsonable_encoder
-from typing import Any
-from app import crud, tools, models
-from app.crud import crud_mongo
-from app.tools.distance import check_distance
-from app.tools.rsrp_calculation import check_rsrp, check_path_loss
-from app.tools import qos_callback
-from app.db.session import SessionLocal, client
+
+from app import crud, models, tools
 from app.api import deps
+from app.crud import crud_mongo
+from app.db.session import SessionLocal, client
+from app.models.UE import UE
 from app.schemas import Msg
-from app.schemas.afSessionWithQos import AsSessionWithQoSSubscription
-from app.tools import monitoring_callbacks, timer
-
-from app.schemas.UE import UE
-
 from app.schemas.monitoringevent import Point
-from app.tools import monitoring_callbacks, timer
+from app.schemas.UE import UE
+from app.tools import monitoring_callbacks, qos_callback, timer
+from app.tools.distance import check_distance
+from app.tools.rsrp_calculation import check_path_loss, check_rsrp
 
 # Dictionary holding threads that are running per user id.
 threads = {}

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -14,7 +14,6 @@ from app.db.session import SessionLocal, client
 from app.models.UE import UE
 from app.schemas import Msg
 from app.schemas.monitoringevent import Point
-from app.schemas.UE import UE
 from app.tools import monitoring_callbacks, qos_callback, timer
 from app.tools.distance import check_distance
 from app.tools.rsrp_calculation import check_path_loss, check_rsrp

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -1,10 +1,8 @@
-import threading
-import logging
-import time
-import requests
+import threading, logging, time, requests
+from app.models.UE import UE
 from fastapi import APIRouter, Path, Depends, HTTPException
 from fastapi.encoders import jsonable_encoder
-from typing import Any
+from typing import Any, Literal, Optional
 from app import crud, tools, models
 from app.crud import crud_mongo
 from app.tools.distance import check_distance
@@ -16,19 +14,21 @@ from app.schemas import Msg
 from app.schemas.afSessionWithQos import AsSessionWithQoSSubscription
 from app.tools import monitoring_callbacks, timer
 
-#Dictionary holding threads that are running per user id.
+from fastapi import BackgroundTasks
+
+# Dictionary holding threads that are running per user id.
 threads = {}
 
-#Dictionary holding UEs' information
+# Dictionary holding UEs' information
 ues = {}
 
-#Dictionary holding UEs' distances to cells
+# Dictionary holding UEs' distances to cells
 distances = {}
 
-#Dictionary holding UEs' path losses in reference to cells
+# Dictionary holding UEs' path losses in reference to cells
 path_losses = {}
 
-#Dictionary holding UEs' path losses in reference to cells
+# Dictionary holding UEs' path losses in reference to cells
 rsrps = {}
 
 handovers = {}
@@ -37,10 +37,12 @@ handovers = {}
 # channel = connection.channel()
 # channel.queue_declare(queue='my_queue')
 
+# TODO: Remove this
+
 class BackgroundTasks(threading.Thread):
 
-    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None): 
-        super().__init__(group=group, target=target,  name=name)
+    def __init__(self, group=None, target=None, name=None, args=(), kwargs=None):
+        super().__init__(group=group, target=target, name=name)
         self._args = args
         self._kwargs = kwargs
         self._stop_threads = False
@@ -48,38 +50,38 @@ class BackgroundTasks(threading.Thread):
         return
 
     def run(self):
-        
+
         current_user = self._args[0]
         supi = self._args[1]
-        
+
         active_subscriptions = {
-            "location_reporting" : False,
-            "ue_reachability" : False,
-            "loss_of_connectivity" : False,
-            "as_session_with_qos" : False
+            "location_reporting": False,
+            "ue_reachability": False,
+            "loss_of_connectivity": False,
+            "as_session_with_qos": False,
         }
 
         try:
             db_mongo = client.fastapi
 
-            #Connect to broker
+            # Connect to broker
 
             # connection = pika.BlockingConnection(pika.ConnectionParameters('rabbitmq'))
             # channel = connection.channel()
             # channel.queue_declare(queue='my_queue')
 
-            #Initiate UE - if exists
+            # Initiate UE - if exists
             UE = crud.ue.get_supi(db=self._db, supi=supi)
             if not UE:
                 logging.warning("UE not found")
                 threads.pop(f"{supi}")
                 return
-            if (UE.owner_id != current_user.id):
+            if UE.owner_id != current_user.id:
                 logging.warning("Not enough permissions")
                 threads.pop(f"{supi}")
                 return
-            
-            #Insert running UE in the dictionary
+
+            # Insert running UE in the dictionary
 
             global ues, distances, handovers
             ues[f"{supi}"] = jsonable_encoder(UE)
@@ -92,36 +94,13 @@ class BackgroundTasks(threading.Thread):
                 ues[f"{supi}"]["cell_id_hex"] = None
                 ues[f"{supi}"]["gnb_id_hex"] = None
 
-            
-            # # Define a callback function for processing the received message
-            # def process_message(ch, method, properties, body):
-            #     global ues                
-            #     try:
-            #         # Process the received message
-            #         value = float(body)
-            #         print("Received message:", value)
-                    
-            #         # Attribute values to the UE entity
-            #         ues[f"{supi}"]["uplink"]  = value
-
-            #         channel.stop_consuming()                    
-            #     except Exception as ex:
-            #         logging.error(f"Failed to process message: {ex}")
-            
-            # # Set up the message consumer
-            # channel.basic_consume(queue='my_queue', on_message_callback=process_message, auto_ack=True)
-
-            # # Start consuming messages
-            # print("Consumer started. Waiting for messages...")
-            # channel.start_consuming()
-
-            #Retrieve paths & points
+            # Retrieve paths & points
             path = crud.path.get(db=self._db, id=UE.path_id)
             if not path:
                 logging.warning("Path not found")
                 threads.pop(f"{supi}")
                 return
-            if (path.owner_id != current_user.id):
+            if path.owner_id != current_user.id:
                 logging.warning("Not enough permissions")
                 threads.pop(f"{supi}")
                 return
@@ -129,8 +108,10 @@ class BackgroundTasks(threading.Thread):
             points = crud.points.get_points(db=self._db, path_id=UE.path_id)
             points = jsonable_encoder(points)
 
-            #Retrieve all the cells
-            Cells = crud.cell.get_multi_by_owner(db=self._db, owner_id=current_user.id, skip=0, limit=100)
+            # Retrieve all the cells
+            Cells = crud.cell.get_multi_by_owner(
+                db=self._db, owner_id=current_user.id, skip=0, limit=100
+            )
             json_cells = jsonable_encoder(Cells)
 
             is_superuser = crud.user.is_superuser(current_user)
@@ -139,7 +120,7 @@ class BackgroundTasks(threading.Thread):
             rt = None
             # global loss_of_connectivity_ack
             loss_of_connectivity_ack = "FALSE"
-            '''
+            """
             ===================================================================
                                2nd Approach for updating UEs position
             ===================================================================
@@ -167,13 +148,15 @@ class BackgroundTasks(threading.Thread):
             Cons:    - skipping points and updating once every second decreases the event resolution
 
             -------------------------------------------------------------------
-            '''
+            """
 
             current_position_index = -1
 
             # find the index of the point where the UE is located
             for index, point in enumerate(points):
-                if (UE.latitude == point["latitude"]) and (UE.longitude == point["longitude"]):
+                if (UE.latitude == point["latitude"]) and (
+                    UE.longitude == point["longitude"]
+                ):
                     current_position_index = index
 
             # start iterating from this index and keep increasing the moving_position_index...
@@ -188,79 +171,142 @@ class BackgroundTasks(threading.Thread):
                         db_obj=UE,
                     )
                     # cell_now = check_distance(UE.latitude, UE.longitude, json_cells) #calculate the distance from all the cells
-                    ues[f"{supi}"]["latitude"] = points[current_position_index]["latitude"]
-                    ues[f"{supi}"]["longitude"] = points[current_position_index]["longitude"]
-                    cell_now, distances_now = check_distance(ues[f"{supi}"]["latitude"], ues[f"{supi}"]["longitude"], json_cells) #calculate the distance from all the cells
+                    ues[f"{supi}"]["latitude"] = points[current_position_index][
+                        "latitude"
+                    ]
+                    ues[f"{supi}"]["longitude"] = points[current_position_index][
+                        "longitude"
+                    ]
+                    cell_now, distances_now = check_distance(
+                        ues[f"{supi}"]["latitude"],
+                        ues[f"{supi}"]["longitude"],
+                        json_cells,
+                    )  # calculate the distance from all the cells
                     distances[f"{supi}"] = distances_now
-                    path_losses_now = check_path_loss(ues[f"{supi}"]["latitude"], ues[f"{supi}"]["longitude"], json_cells)
+                    path_losses_now = check_path_loss(
+                        ues[f"{supi}"]["latitude"],
+                        ues[f"{supi}"]["longitude"],
+                        json_cells,
+                    )
                     path_losses[f"{supi}"] = path_losses_now
-                    rsrp_now = check_rsrp(ues[f"{supi}"]["latitude"], ues[f"{supi}"]["longitude"], json_cells)
+                    rsrp_now = check_rsrp(
+                        ues[f"{supi}"]["latitude"],
+                        ues[f"{supi}"]["longitude"],
+                        json_cells,
+                    )
                     rsrps[f"{supi}"] = rsrp_now
 
                 except Exception as ex:
                     logging.warning("Failed to update coordinates")
                     logging.warning(ex)
-                
-                
-                #MonitoringEvent API - Loss of connectivity
-                if not active_subscriptions.get("loss_of_connectivity"):
-                    loss_of_connectivity_sub = crud_mongo.read_by_multiple_pairs(db_mongo, "MonitoringEvent", externalId = UE.external_identifier, monitoringType = "LOSS_OF_CONNECTIVITY")
-                    if loss_of_connectivity_sub:
-                        active_subscriptions.update({"loss_of_connectivity" : True})
-                    
 
-                #Validation of subscription
-                if active_subscriptions.get("loss_of_connectivity") and loss_of_connectivity_ack == "FALSE":
-                    sub_is_valid = monitoring_event_sub_validation(loss_of_connectivity_sub, is_superuser, current_user.id, loss_of_connectivity_sub.get("owner_id"))    
+                # MonitoringEvent API - Loss of connectivity
+                if not active_subscriptions.get("loss_of_connectivity"):
+                    loss_of_connectivity_sub = crud_mongo.read_by_multiple_pairs(
+                        db_mongo,
+                        "MonitoringEvent",
+                        externalId=UE.external_identifier,
+                        monitoringType="LOSS_OF_CONNECTIVITY",
+                    )
+                    if loss_of_connectivity_sub:
+                        active_subscriptions.update({"loss_of_connectivity": True})
+
+                # Validation of subscription
+                if (
+                    active_subscriptions.get("loss_of_connectivity")
+                    and loss_of_connectivity_ack == "FALSE"
+                ):
+                    sub_is_valid = monitoring_event_sub_validation(
+                        loss_of_connectivity_sub,
+                        is_superuser,
+                        current_user.id,
+                        loss_of_connectivity_sub.get("owner_id"),
+                    )
                     if sub_is_valid:
                         try:
                             try:
                                 elapsed_time = t.status()
-                                if elapsed_time > loss_of_connectivity_sub.get("maximumDetectionTime"):
-                                    response = monitoring_callbacks.loss_of_connectivity_callback(ues[f"{supi}"], loss_of_connectivity_sub.get("notificationDestination"), loss_of_connectivity_sub.get("link"))
-                                    
+                                if elapsed_time > loss_of_connectivity_sub.get(
+                                    "maximumDetectionTime"
+                                ):
+                                    response = monitoring_callbacks.loss_of_connectivity_callback(
+                                        ues[f"{supi}"],
+                                        loss_of_connectivity_sub.get(
+                                            "notificationDestination"
+                                        ),
+                                        loss_of_connectivity_sub.get("link"),
+                                    )
+
                                     logging.critical(response.json())
-                                    #This ack is used to send one time the loss of connectivity callback
-                                    loss_of_connectivity_ack = response.json().get("ack")
-                                    
-                                    loss_of_connectivity_sub.update({"maximumNumberOfReports" : loss_of_connectivity_sub.get("maximumNumberOfReports") - 1})
-                                    crud_mongo.update(db_mongo, "MonitoringEvent", loss_of_connectivity_sub.get("_id"), loss_of_connectivity_sub)
-                            except timer.TimerError:
+                                    # This ack is used to send one time the loss of connectivity callback
+                                    loss_of_connectivity_ack = response.json().get(
+                                        "ack"
+                                    )
+
+                                    loss_of_connectivity_sub.update(
+                                        {
+                                            "maximumNumberOfReports": loss_of_connectivity_sub.get(
+                                                "maximumNumberOfReports"
+                                            )
+                                            - 1
+                                        }
+                                    )
+                                    crud_mongo.update(
+                                        db_mongo,
+                                        "MonitoringEvent",
+                                        loss_of_connectivity_sub.get("_id"),
+                                        loss_of_connectivity_sub,
+                                    )
+                            except timer.TimerError as ex:
                                 # logging.critical(ex)
                                 pass
                         except requests.exceptions.ConnectionError as ex:
                             logging.warning("Failed to send the callback request")
                             logging.warning(ex)
-                            crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", loss_of_connectivity_sub.get("_id"))
-                            active_subscriptions.update({"loss_of_connectivity" : False})
+                            crud_mongo.delete_by_uuid(
+                                db_mongo,
+                                "MonitoringEvent",
+                                loss_of_connectivity_sub.get("_id"),
+                            )
+                            active_subscr_iptions.update(
+                                {"loss_of_connectivity": False}
+                            )
                             continue
                     else:
-                        crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", loss_of_connectivity_sub.get("_id"))
-                        active_subscriptions.update({"loss_of_connectivity" : False})
+                        crud_mongo.delete_by_uuid(
+                            db_mongo,
+                            "MonitoringEvent",
+                            loss_of_connectivity_sub.get("_id"),
+                        )
+                        active_subscriptions.update({"loss_of_connectivity": False})
                         logging.warning("Subscription has expired")
-                #MonitoringEvent API - Loss of connectivity
+                # MonitoringEvent API - Loss of connectivity
 
-                #As Session With QoS API - search for active subscription in db
+                # As Session With QoS API - search for active subscription in db
                 if not active_subscriptions.get("as_session_with_qos"):
-                    filters = {"ues": UE.supi}
-                    if not is_superuser:
-                        filters["owner_id"] = current_user.id
-                    qos_sub = db_mongo["QoSMonitoring"].find_one(
-                        filters,
-                        projection={"_id": False, "subscription": True}
+                    qos_sub = crud_mongo.read(
+                        db_mongo, "QoSMonitoring", "ipv4Addr", UE.ip_address_v4
                     )
+                    if qos_sub:
+                        active_subscriptions.update({"as_session_with_qos": True})
+                        reporting_freq = qos_sub["qosMonInfo"]["repFreqs"]
+                        reporting_period = qos_sub["qosMonInfo"]["repPeriod"]
+                        if "PERIODIC" in reporting_freq:
+                            rt = timer.RepeatedTimer(
+                                reporting_period,
+                                qos_callback.qos_notification_control,
+                                qos_sub,
+                                ues[f"{supi}"]["ip_address_v4"],
+                                ues.copy(),
+                                ues[f"{supi}"],
+                            )
+                            # qos_callback.qos_notification_control(qos_sub, ues[f"{supi}"]["ip_address_v4"], ues.copy(),  ues[f"{supi}"])
 
-                    if qos_sub is not None:
-                        qos_sub = AsSessionWithQoSSubscription.parse_obj(qos_sub["subscription"])
-                        if qos_sub.qosMonInfo is not None:
-                            active_subscriptions.update({"as_session_with_qos" : True})
-                            reporting_freq = qos_sub.qosMonInfo.repFreqs
-                            reporting_period = qos_sub.qosMonInfo.repPeriod
-                            if "PERIODIC" in reporting_freq:
-                                rt = timer.RepeatedTimer(reporting_period, qos_callback.qos_notification_control, qos_sub, ues.copy(), ues[f"{supi}"])
-                                # qos_callback.qos_notification_control(qos_sub, ues[f"{supi}"]["ip_address_v4"], ues.copy(),  ues[f"{supi}"])
-
-                #As Session With QoS API - search for active subscription in db
+                # If the document exists then validate the owner
+                if not is_superuser and (qos_sub["owner_id"] != current_user.id):
+                    logging.warning("Not enough permissions")
+                    active_subscriptions.update({"as_session_with_qos": False})
+                # As Session With QoS API - search for active subscription in db
 
                 if cell_now != None:
                     try:
@@ -273,94 +319,185 @@ class BackgroundTasks(threading.Thread):
                         pass
 
                     # if UE.Cell_id != cell_now.get('id'): #Cell has changed in the db "handover"
-                    if ues[f"{supi}"]["Cell_id"] != cell_now.get('id'): #Cell has changed in the db "handover"
-                        
-                        #Monitoring Event API - UE reachability 
-                        #check if the ue was disconnected before
-                        if ues[f"{supi}"]["Cell_id"] == None:
-                            
-                            if not active_subscriptions.get("ue_reachability"):
-                                ue_reachability_sub = crud_mongo.read_by_multiple_pairs(db_mongo, "MonitoringEvent", externalId = UE.external_identifier, monitoringType = "UE_REACHABILITY")
-                                if ue_reachability_sub:
-                                    active_subscriptions.update({"ue_reachability" : True})
+                    if ues[f"{supi}"]["Cell_id"] != cell_now.get(
+                        "id"
+                    ):  # Cell has changed in the db "handover"
 
-                            #Validation of subscription    
-                             
+                        # Monitoring Event API - UE reachability
+                        # check if the ue was disconnected before
+                        if ues[f"{supi}"]["Cell_id"] == None:
+
+                            if not active_subscriptions.get("ue_reachability"):
+                                ue_reachability_sub = crud_mongo.read_by_multiple_pairs(
+                                    db_mongo,
+                                    "MonitoringEvent",
+                                    externalId=UE.external_identifier,
+                                    monitoringType="UE_REACHABILITY",
+                                )
+                                if ue_reachability_sub:
+                                    active_subscriptions.update(
+                                        {"ue_reachability": True}
+                                    )
+
+                            # Validation of subscription
+
                             if active_subscriptions.get("ue_reachability"):
-                                sub_is_valid = monitoring_event_sub_validation(ue_reachability_sub, is_superuser, current_user.id, ue_reachability_sub.get("owner_id"))   
+                                sub_is_valid = monitoring_event_sub_validation(
+                                    ue_reachability_sub,
+                                    is_superuser,
+                                    current_user.id,
+                                    ue_reachability_sub.get("owner_id"),
+                                )
                                 if sub_is_valid:
                                     try:
                                         try:
-                                            monitoring_callbacks.ue_reachability_callback(ues[f"{supi}"], ue_reachability_sub.get("notificationDestination"), ue_reachability_sub.get("link"), ue_reachability_sub.get("reachabilityType"))
-                                            ue_reachability_sub.update({"maximumNumberOfReports" : ue_reachability_sub.get("maximumNumberOfReports") - 1})
-                                            crud_mongo.update(db_mongo, "MonitoringEvent", ue_reachability_sub.get("_id"), ue_reachability_sub)
-                                        except timer.TimerError:
+                                            monitoring_callbacks.ue_reachability_callback(
+                                                ues[f"{supi}"],
+                                                ue_reachability_sub.get(
+                                                    "notificationDestination"
+                                                ),
+                                                ue_reachability_sub.get("link"),
+                                                ue_reachability_sub.get(
+                                                    "reachabilityType"
+                                                ),
+                                            )
+                                            ue_reachability_sub.update(
+                                                {
+                                                    "maximumNumberOfReports": ue_reachability_sub.get(
+                                                        "maximumNumberOfReports"
+                                                    )
+                                                    - 1
+                                                }
+                                            )
+                                            crud_mongo.update(
+                                                db_mongo,
+                                                "MonitoringEvent",
+                                                ue_reachability_sub.get("_id"),
+                                                ue_reachability_sub,
+                                            )
+                                        except timer.TimerError as ex:
                                             # logging.critical(ex)
                                             pass
                                     except requests.exceptions.ConnectionError as ex:
-                                        logging.warning("Failed to send the callback request")
+                                        logging.warning(
+                                            "Failed to send the callback request"
+                                        )
                                         logging.warning(ex)
-                                        crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", ue_reachability_sub.get("_id"))
-                                        active_subscriptions.update({"ue_reachability" : False})
+                                        crud_mongo.delete_by_uuid(
+                                            db_mongo,
+                                            "MonitoringEvent",
+                                            ue_reachability_sub.get("_id"),
+                                        )
+                                        active_subscriptions.update(
+                                            {"ue_reachability": False}
+                                        )
                                         continue
                                 else:
-                                    crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", ue_reachability_sub.get("_id"))
-                                    active_subscriptions.update({"ue_reachability" : False})
+                                    crud_mongo.delete_by_uuid(
+                                        db_mongo,
+                                        "MonitoringEvent",
+                                        ue_reachability_sub.get("_id"),
+                                    )
+                                    active_subscriptions.update(
+                                        {"ue_reachability": False}
+                                    )
                                     logging.warning("Subscription has expired")
-                         #Monitoring Event API - UE reachability
-                        
-                        
-                        logging.warning(f"UE({UE.supi}) with ipv4 {UE.ip_address_v4} handovers to Cell {cell_now.get('id')}, {cell_now.get('description')}")
-                        
+                        # Monitoring Event API - UE reachability
+
+                        logging.warning(
+                            f"UE({UE.supi}) with ipv4 {UE.ip_address_v4} handovers to Cell {cell_now.get('id')}, {cell_now.get('description')}"
+                        )
+
                         if f"{UE.supi}" not in handovers.keys():
                             handovers[f"{UE.supi}"] = []
-                            
 
-                        handovers[f"{UE.supi}"].append(cell_now.get('id'))
+                        handovers[f"{UE.supi}"].append(cell_now.get("id"))
 
-                        ues[f"{supi}"]["Cell_id"] = cell_now.get('id')
-                        ues[f"{supi}"]["cell_id_hex"] = cell_now.get('cell_id')
+                        ues[f"{supi}"]["Cell_id"] = cell_now.get("id")
+                        ues[f"{supi}"]["cell_id_hex"] = cell_now.get("cell_id")
                         gnb = crud.gnb.get(db=self._db, id=cell_now.get("gNB_id"))
                         ues[f"{supi}"]["gnb_id_hex"] = gnb.gNB_id
 
-                    
-                    #Monitoring Event API - Location Reporting
-                    #Retrieve the subscription of the UE by external Id | This could be outside while true but then the user cannot subscribe when the loop runs
+                    # Monitoring Event API - Location Reporting
+                    # Retrieve the subscription of the UE by external Id | This could be outside while true but then the user cannot subscribe when the loop runs
                     if not active_subscriptions.get("location_reporting"):
-                        location_reporting_sub = crud_mongo.read_by_multiple_pairs(db_mongo, "MonitoringEvent", externalId = UE.external_identifier, monitoringType = "LOCATION_REPORTING")
+                        location_reporting_sub = crud_mongo.read_by_multiple_pairs(
+                            db_mongo,
+                            "MonitoringEvent",
+                            externalId=UE.external_identifier,
+                            monitoringType="LOCATION_REPORTING",
+                        )
                         if location_reporting_sub:
-                            active_subscriptions.update({"location_reporting" : True})
+                            active_subscriptions.update({"location_reporting": True})
 
-                    #Validation of subscription    
-                    if active_subscriptions.get("location_reporting"): 
-                        sub_is_valid = monitoring_event_sub_validation(location_reporting_sub, is_superuser, current_user.id, location_reporting_sub.get("owner_id"))    
+                    # Validation of subscription
+                    if active_subscriptions.get("location_reporting"):
+                        sub_is_valid = monitoring_event_sub_validation(
+                            location_reporting_sub,
+                            is_superuser,
+                            current_user.id,
+                            location_reporting_sub.get("owner_id"),
+                        )
                         if sub_is_valid:
                             try:
                                 try:
-                                    monitoring_callbacks.location_callback(ues[f"{supi}"], location_reporting_sub.get("notificationDestination"), location_reporting_sub.get("link"))
-                                    location_reporting_sub.update({"maximumNumberOfReports" : location_reporting_sub.get("maximumNumberOfReports") - 1})
-                                    crud_mongo.update(db_mongo, "MonitoringEvent", location_reporting_sub.get("_id"), location_reporting_sub)
-                                except timer.TimerError:
+                                    monitoring_callbacks.location_callback(
+                                        ues[f"{supi}"],
+                                        location_reporting_sub.get(
+                                            "notificationDestination"
+                                        ),
+                                        location_reporting_sub.get("link"),
+                                    )
+                                    location_reporting_sub.update(
+                                        {
+                                            "maximumNumberOfReports": location_reporting_sub.get(
+                                                "maximumNumberOfReports"
+                                            )
+                                            - 1
+                                        }
+                                    )
+                                    crud_mongo.update(
+                                        db_mongo,
+                                        "MonitoringEvent",
+                                        location_reporting_sub.get("_id"),
+                                        location_reporting_sub,
+                                    )
+                                except timer.TimerError as ex:
                                     # logging.critical(ex)
                                     pass
                             except requests.exceptions.ConnectionError as ex:
                                 logging.warning("Failed to send the callback request")
                                 logging.warning(ex)
-                                crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", location_reporting_sub.get("_id"))
-                                active_subscriptions.update({"location_reporting" : False})
+                                crud_mongo.delete_by_uuid(
+                                    db_mongo,
+                                    "MonitoringEvent",
+                                    location_reporting_sub.get("_id"),
+                                )
+                                active_subscriptions.update(
+                                    {"location_reporting": False}
+                                )
                                 continue
                         else:
-                            crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", location_reporting_sub.get("_id"))
-                            active_subscriptions.update({"location_reporting" : False})
+                            crud_mongo.delete_by_uuid(
+                                db_mongo,
+                                "MonitoringEvent",
+                                location_reporting_sub.get("_id"),
+                            )
+                            active_subscriptions.update({"location_reporting": False})
                             logging.warning("Subscription has expired")
-                    #Monitoring Event API - Location Reporting
-                    
-                    #As Session With QoS API - if EVENT_TRIGGER then send callback on handover
+                    # Monitoring Event API - Location Reporting
+
+                    # As Session With QoS API - if EVENT_TRIGGER then send callback on handover
                     if active_subscriptions.get("as_session_with_qos"):
                         reporting_freq = qos_sub.qosMonInfo.repFreqs
                         if "EVENT_TRIGGERED" in reporting_freq:
-                            qos_callback.qos_notification_control(qos_sub, ues.copy(), ues[f"{supi}"])
-                    #As Session With QoS API - if EVENT_TRIGGER then send callback on handover
+                            qos_callback.qos_notification_control(
+                                qos_sub,
+                                ues[f"{supi}"]["ip_address_v4"],
+                                ues.copy(),
+                                ues[f"{supi}"],
+                            )
+                    # As Session With QoS API - if EVENT_TRIGGER then send callback on handover
 
                 else:
                     # crud.ue.update(db=db, db_obj=UE, obj_in={"Cell_id" : None})
@@ -377,34 +514,40 @@ class BackgroundTasks(threading.Thread):
                     ues[f"{supi}"]["gnb_id_hex"] = None
 
                 # logging.info(f'User: {current_user.id} | UE: {supi} | Current location: latitude ={UE.latitude} | longitude = {UE.longitude} | Speed: {UE.speed}' )
-                
-                if UE.speed == 'LOW':
+
+                if UE.speed == "LOW":
                     # don't skip any points, keep default speed 1m /sec
                     moving_position_index += 1
-                elif UE.speed == 'HIGH':
+                elif UE.speed == "HIGH":
                     # skip 10 points --> 10m / sec
                     moving_position_index += 10
 
                 time.sleep(1)
 
-                current_position_index = moving_position_index%(len(points))
+                current_position_index = moving_position_index % (len(points))
 
-                
                 if self._stop_threads:
                     logging.critical("Terminating thread...")
-                    crud.ue.update_coordinates(db=self._db, lat=ues[f"{supi}"]["latitude"], long=ues[f"{supi}"]["longitude"], db_obj=UE)
-                    crud.ue.update(db=self._db, db_obj=UE, obj_in={"Cell_id" : ues[f"{supi}"]["Cell_id"]})
+                    crud.ue.update_coordinates(
+                        db=self._db,
+                        lat=ues[f"{supi}"]["latitude"],
+                        long=ues[f"{supi}"]["longitude"],
+                        db_obj=UE,
+                    )
+                    crud.ue.update(
+                        db=self._db,
+                        db_obj=UE,
+                        obj_in={"Cell_id": ues[f"{supi}"]["Cell_id"]},
+                    )
                     ues.pop(f"{supi}")
                     self._db.close()
                     if rt is not None:
                         rt.stop()
                     break
-            
+
             # End of 2nd Approach for updating UEs position
 
-
-
-            '''
+            """
             ===================================================================
                              1st Approach for updating UEs position
             ===================================================================
@@ -427,10 +570,10 @@ class BackgroundTasks(threading.Thread):
             Cons:    - updating the UE position every 0.1 sec is a more aggressive approach
 
             -------------------------------------------------------------------
-            '''
+            """
 
             # flag = True
-            
+
             # while True:
             #     for point in points:
 
@@ -441,22 +584,21 @@ class BackgroundTasks(threading.Thread):
             #         elif (UE.latitude == point["latitude"]) and (UE.longitude == point["longitude"]) and flag == True:
             #             flag = False
             #             continue
-                    
 
             #         #-----------------------Code goes here-------------------------#
-                    
+
             #         if UE.speed == 'LOW':
             #             time.sleep(1)
             #         elif UE.speed == 'HIGH':
             #             time.sleep(0.1)
-        
+
             #         if self._stop_threads:
             #             print("Stop moving...")
-            #             break       
+            #             break
 
             #     if self._stop_threads:
             #             print("Terminating thread...")
-            #             break       
+            #             break
 
         except Exception as ex:
             logging.critical(ex)
@@ -464,30 +606,108 @@ class BackgroundTasks(threading.Thread):
     def stop(self):
         self._stop_threads = True
 
-#API
+
+# API
 router = APIRouter()
+
+moving_devices = dict()
+
+Speed = Literal["HIGH", "LOW"]
+
+
+def increment_position(speed: Speed) -> int:
+    if speed == "LOW":
+        return 1
+
+    if speed == "HIGH":
+        return 10
+
+
+def validate_ue(*, ue: Optional[UE], user: models.User, db) -> Optional[UE]:
+    if not ue:
+        logging.warning("UE not found")
+        return None
+
+    if ue.owner_id != user.id:
+        logging.warning("Not enough permissions")
+        return None
+
+    path = crud.path.get(db=db, id=ue.path_id)
+    if not path:
+        logging.warning("Path not found")
+        return None
+
+    if path.owner_id != user.id:
+        logging.warning("Not enough permissions")
+        return None
+
+    return ue
+
+
+def movement_loop(supi: str, user: models.User):
+    db = SessionLocal()
+    ue = validate_ue(ue=crud.ue.get_supi(db=db, supi=supi), user=user, db=db)
+
+    if ue is None:
+        moving_devices.pop(supi)
+        return
+
+    points = crud.points.get_points(db=db, path_id=ue.path_id)
+
+    # Assume end of path
+    current_position_index = -1
+
+    # Find current position if one exists
+    for index, point in enumerate(points):
+        if (ue.latitude == point.latitude) and (ue.longitude == point.longitude):
+            current_position_index = index
+            break
+
+    while True:
+        if supi not in moving_devices:
+            break
+
+        current_position_index += increment_position(ue.speed) % len(points)
+        point = points[current_position_index]
+
+        ue = crud.ue.update_coordinates(
+            db=db, lat=point.latitude, long=point.longitude, db_obj=ue
+        )
+
+        location_notification(ue)
+
+        time.sleep(1)
+
+
+def location_notification(ue: UE):
+    pass
+
 
 @router.post("/start-loop", status_code=200)
 def initiate_movement(
     *,
     msg: Msg,
     current_user: models.User = Depends(deps.get_current_active_user),
+    background_tasks: BackgroundTasks,
 ) -> Any:
     """
     Start the loop.
     """
-    if msg.supi in threads:
-        raise HTTPException(status_code=409, detail=f"There is a thread already running for this supi:{msg.supi}")
-    t = BackgroundTasks(args= (current_user, msg.supi, ))
-    threads[f"{msg.supi}"] = {}
-    threads[f"{msg.supi}"][f"{current_user.id}"] = t
-    t.start()
-    # print(threads)
+    if msg.supi in moving_devices:
+        raise HTTPException(
+            status_code=409,
+            detail=f"There is a thread already running for this supi:{msg.supi}",
+        )
+
+    moving_devices[msg.supi] = current_user.id
+    background_tasks.add_task(movement_loop, msg.supi, current_user)
+
     return {"msg": "Loop started"}
+
 
 @router.post("/stop-loop", status_code=200)
 def terminate_movement(
-     *,
+    *,
     msg: Msg,
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
@@ -495,13 +715,17 @@ def terminate_movement(
     Stop the loop.
     """
     try:
-        threads[f"{msg.supi}"][f"{current_user.id}"].stop() 
+        threads[f"{msg.supi}"][f"{current_user.id}"].stop()
         threads[f"{msg.supi}"][f"{current_user.id}"].join()
         threads.pop(f"{msg.supi}")
         return {"msg": "Loop ended"}
     except KeyError as ke:
-        print('Key Not Found in Threads Dictionary:', ke)
-        raise HTTPException(status_code=409, detail="There is no thread running for this user! Please initiate a new thread")
+        print("Key Not Found in Threads Dictionary:", ke)
+        raise HTTPException(
+            status_code=409,
+            detail="There is no thread running for this user! Please initiate a new thread",
+        )
+
 
 @router.get("/state-loop/{supi}", status_code=200)
 def state_movement(
@@ -514,6 +738,7 @@ def state_movement(
     """
     return {"running": retrieve_ue_state(supi, current_user.id)}
 
+
 @router.get("/state-ues", status_code=200)
 def state_ues(
     current_user: models.User = Depends(deps.get_current_active_user),
@@ -523,28 +748,35 @@ def state_ues(
     """
     return ues
 
-#Functions
-def retrieve_ue_state(supi: str, user_id: int) -> bool: 
+
+# Functions
+def retrieve_ue_state(supi: str, user_id: int) -> bool:
     try:
         return threads[f"{supi}"][f"{user_id}"].is_alive()
     except KeyError as ke:
-        print('Key Not Found in Threads Dictionary:', ke)
+        print("Key Not Found in Threads Dictionary:", ke)
         return False
+
 
 def retrieve_ues() -> dict:
     return ues
 
+
 def retrieve_ue(supi: str) -> dict:
     return ues.get(supi)
+
 
 def retrieve_ue_distances(supi: str) -> dict:
     return distances.get(supi)
 
+
 def retrieve_ue_path_losses(supi: str) -> dict:
     return path_losses.get(supi)
 
+
 def retrieve_ue_rsrps(supi: str) -> dict:
     return rsrps.get(supi)
+
 
 def retrieve_ue_handovers(supi: str) -> dict:
     result = handovers.get(supi)
@@ -552,15 +784,21 @@ def retrieve_ue_handovers(supi: str) -> dict:
         return handovers.get(supi)
     return []
 
-def monitoring_event_sub_validation(sub: dict, is_superuser: bool, current_user_id: int, owner_id) -> bool:
-    
+
+def monitoring_event_sub_validation(
+    sub: dict, is_superuser: bool, current_user_id: int, owner_id
+) -> bool:
+
     if not is_superuser and (owner_id != current_user_id):
         # logging.warning("Not enough permissions")
         return False
     else:
-        sub_validate_time = tools.check_expiration_time(expire_time=sub.get("monitorExpireTime"))
-        sub_validate_number_of_reports = tools.check_numberOfReports(sub.get("maximumNumberOfReports"))
+        sub_validate_time = tools.check_expiration_time(
+            expire_time=sub.get("monitorExpireTime")
+        )
+        sub_validate_number_of_reports = tools.check_numberOfReports(
+            sub.get("maximumNumberOfReports")
+        )
         if sub_validate_time and sub_validate_number_of_reports:
             return True
         else:
-            return False

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -387,93 +387,58 @@ def location_notification(ue: UE):
             crud_mongo.delete_by_uuid(db_mongo, "MonitoringEvent", sub.get("_id"))
             continue
 
-        if sub.monitoringType == "LOCATION_REPORTING":
+        monitoringType = sub["monitoringType"]
+
+        if monitoringType == "LOCATION_REPORTING":
             handle_location_report_callback(sub, ue)
 
-        elif sub.monitoringType == "LOSS_OF_CONNECTIVITY":
+        elif monitoringType == "LOSS_OF_CONNECTIVITY":
             handle_loss_connectivity_callback(sub, ue)
 
-        elif sub.monitoringType == "UE_REACHABILITY":
+        elif monitoringType == "UE_REACHABILITY":
             handle_ue_reachability_callback(sub, ue)
 
 
-def handle_location_report_callback(ue_reachability_sub, ue: UE):
+def handle_location_report_callback(location_reporting_sub, ue: UE):
     db_mongo = client.fastapi
     try:
-        monitoring_callbacks.ue_reachability_callback(
-            ue,
-            ue_reachability_sub.get("notificationDestination"),
-            ue_reachability_sub.get("link"),
-            ue_reachability_sub.get("reachabilityType"),
+        logging.info(
+            "Attempting to send the callback to %d",
+            location_reporting_sub.get("notificationDestination"),
         )
-
-        if ue_reachability_sub.maximumNumberOfReports:
-            ue_reachability_sub.update(
-                {
-                    "maximumNumberOfReports": ue_reachability_sub.get(
-                        "maximumNumberOfReports"
-                    )
-                    - 1
-                }
-            )
-
-            crud_mongo.update(
-                db_mongo,
-                "MonitoringEvent",
-                ue_reachability_sub.get("_id"),
-                ue_reachability_sub,
-            )
-
-    except requests.exceptions.ConnectionError as ex:
-        logging.warning(f"Failed to send the callback request with error {ex}")
-        crud_mongo.delete_by_uuid(
+        print(
+            f"Attempting to send the callback to {location_reporting_sub.get('notificationDestination')}"
+        )
+        monitoring_callbacks.location_callback(
+            jsonable_encoder(ue),
+            location_reporting_sub.get("notificationDestination"),
+            location_reporting_sub.get("link"),
+        )
+        location_reporting_sub.update(
+            {
+                "maximumNumberOfReports": location_reporting_sub.get(
+                    "maximumNumberOfReports"
+                )
+                - 1
+            }
+        )
+        crud_mongo.update(
             db_mongo,
             "MonitoringEvent",
-            ue_reachability_sub.get("_id"),
+            location_reporting_sub.get("_id"),
+            location_reporting_sub,
         )
+
+    except requests.exceptions.ConnectionError as ex:
+        logging.warning("Failed to send the callback request with error %d", ex)
 
 
 def handle_loss_connectivity_callback(loss_of_connectivity_sub, ue: UE):
-    db_mongo = client.fastapi
-    try:
-        elapsed_time = t.status()
-        if elapsed_time > loss_of_connectivity_sub.get("maximumDetectionTime"):
-            response = monitoring_callbacks.loss_of_connectivity_callback(
-                ue,
-                loss_of_connectivity_sub.get("notificationDestination"),
-                loss_of_connectivity_sub.get("link"),
-            )
-
-            logging.critical(response.json())
-            # This ack is used to send one time the loss of connectivity callback
-            loss_of_connectivity_ack = response.json().get("ack")
-
-            loss_of_connectivity_sub.update(
-                {
-                    "maximumNumberOfReports": loss_of_connectivity_sub.get(
-                        "maximumNumberOfReports"
-                    )
-                    - 1
-                }
-            )
-            crud_mongo.update(
-                db_mongo,
-                "MonitoringEvent",
-                loss_of_connectivity_sub.get("_id"),
-                loss_of_connectivity_sub,
-            )
-    except requests.exceptions.ConnectionError as ex:
-        logging.warning("Failed to send the callback request")
-        logging.warning(ex)
-        crud_mongo.delete_by_uuid(
-            db_mongo,
-            "MonitoringEvent",
-            loss_of_connectivity_sub.get("_id"),
-        )
+    logging.error("There was an attempt at calling the connectivity callback")
 
 
 def handle_ue_reachability_callback(subscription, ue: UE):
-    pass
+    logging.error("There was an attempt at calling the reachability callback")
 
 
 @router.post("/update_location/{supi}", status_code=200)
@@ -493,7 +458,7 @@ def update_location(
             detail="No device found",
         )
 
-    crud.ue.update_coordinates(
+    ue = crud.ue.update_coordinates(
         db,
         lat=new_location.point.lat,
         long=new_location.point.lon,
@@ -501,6 +466,7 @@ def update_location(
     )
 
     # TODO: Send notifications related to location update
+    background_tasks.add_task(location_notification, ue)
 
     return {"msg": "Location updated"}
 

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -100,7 +100,9 @@ def movement_loop(supi: str, user: models.User):
         if supi not in moving_devices:
             break
 
-        current_position_index += increment_position(ue.speed) % len(points)
+        current_position_index = (
+            increment_position(ue.speed) + current_position_index
+        ) % len(points)
         point = points[current_position_index]
 
         cell_now, cell_distances = check_distance(

--- a/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -1,17 +1,13 @@
-import threading, logging, time, requests
-from app.models.UE import UE
-from fastapi import APIRouter, Path, Depends, HTTPException
-from fastapi.encoders import jsonable_encoder
+import logging
+import threading
+import time
 from typing import Any, Literal, Optional
-from fastapi import APIRouter, Path, Depends, HTTPException, BackgroundTasks
+
+import requests
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
 from fastapi.encoders import jsonable_encoder
-from typing import Any
-from app import crud, tools, models
-from app.crud import crud_mongo
-from app.tools.distance import check_distance
-from app.tools.rsrp_calculation import check_rsrp, check_path_loss
-from app.tools import qos_callback
-from app.db.session import SessionLocal, client
+
+from app import crud, models, tools
 from app.api import deps
 from app.crud import crud_mongo
 from app.db.session import SessionLocal, client

--- a/backend/app/app/crud/crud_mongo.py
+++ b/backend/app/app/crud/crud_mongo.py
@@ -1,57 +1,75 @@
 from bson import ObjectId
 from pymongo.database import Database
 
+
 # collection
 # GET (all objects as a list)
 def read_all(db, collection_name, owner):
     collection = db[collection_name]
-    return list(collection.find({'owner_id' : owner}, {'_id': False, 'owner_id' : False}))
+    return list(collection.find({"owner_id": owner}, {"_id": False, "owner_id": False}))
+
 
 # GET (specific object)
-def read_uuid(db : Database, collection_name, uuId):
+def read_uuid(db: Database, collection_name, uuId):
     collection = db[collection_name]
-    return collection.find_one({'_id': ObjectId(uuId)}, {'_id': False})
+    return collection.find_one({"_id": ObjectId(uuId)}, {"_id": False})
+
 
 ##Read by key:value
 
-def read(db : Database, collection_name : str, key : str, value):
-    collection = db[collection_name]
-    return collection.find_one({ key : value })
 
-def read_by_multiple_pairs(db : Database, collection_name : str, **kwargs):
+def read(db: Database, collection_name: str, key: str, value):
     collection = db[collection_name]
-    return collection.find_one({ **kwargs })
+    return collection.find_one({key: value})
+
+
+def read_by_multiple_pairs(db: Database, collection_name: str, **kwargs):
+    collection = db[collection_name]
+    return collection.find_one({**kwargs})
+
+
+def read_all_by_multiple_pairs(db: Database, collection_name: str, **kwargs):
+    collection = db[collection_name]
+    return list(collection.find({**kwargs}))
+
 
 # PUT
 def update(db: Database, collection_name, uuId, json_data):
     return db[collection_name].replace_one({"_id": ObjectId(uuId)}, json_data)
 
+
 ##Add a new field to an existing document (AsSessionWithQoS / QoSMonitoring)
 def update_new_field(db: Database, collection_name, uuId, json_data):
-    return db[collection_name].update_one({'_id': ObjectId(uuId)} , { '$set' : json_data})
+    return db[collection_name].update_one({"_id": ObjectId(uuId)}, {"$set": json_data})
+
 
 # POST
 def create(db: Database, collection_name, json_data):
     return db[collection_name].insert_one(json_data)
+
 
 # DELETE
 def delete_by_uuid(db: Database, collection_name, uuId):
     result = db[collection_name].delete_one({"_id": ObjectId(uuId)})
     return result
 
+
 def delete_by_item(db: Database, collection_name, key: str, value):
     result = db[collection_name].delete_one({key: value})
     return result
 
-#Read all profiles by gNB id (QoSProfile)
 
-def read_all_gNB_profiles(db : Database, collection_name, id):
+# Read all profiles by gNB id (QoSProfile)
+
+
+def read_all_gNB_profiles(db: Database, collection_name, id):
     collection = db[collection_name]
-    return list(collection.find({'gNB_id': id}, {'_id': False}))
+    return list(collection.find({"gNB_id": id}, {"_id": False}))
 
-#Read by gNB/profile (QoSProfile)
 
-def read_gNB_qosprofile(db : Database, collection_name, gNB_id, qos_id):
+# Read by gNB/profile (QoSProfile)
+
+
+def read_gNB_qosprofile(db: Database, collection_name, gNB_id, qos_id):
     collection = db[collection_name]
-    return collection.find_one({'gNB_id': gNB_id, 'value' : qos_id}, {'_id': False})
-
+    return collection.find_one({"gNB_id": gNB_id, "value": qos_id}, {"_id": False})

--- a/backend/app/app/schemas/analyticsExposure.py
+++ b/backend/app/app/schemas/analyticsExposure.py
@@ -3,262 +3,356 @@ from datetime import datetime
 from app.schemas.monitoringevent import CivicAddress, GeographicArea
 from pydantic import BaseModel, Field, IPvAnyAddress, AnyHttpUrl, constr
 from enum import Enum
-from .commonData import Snssai, TimeWindow, FlowInfo, Ecgi, Ncgi, GlobalRanNodeId, Tai, UserLocation, RatType, QosResourceType, AnalyticsSubset, PartitioningCriteria, NotificationFlag, WebsockNotifConfig
+from .commonData import (
+    Snssai,
+    TimeWindow,
+    FlowInfo,
+    Ecgi,
+    Ncgi,
+    GlobalRanNodeId,
+    Tai,
+    UserLocation,
+    RatType,
+    QosResourceType,
+    AnalyticsSubset,
+    PartitioningCriteria,
+    NotificationFlag,
+    WebsockNotifConfig,
+)
 from .cpParameterProvisioning import ScheduledCommunicationTime
 from .utils import ExtraBaseModel
 
 ############### TS 29.517 Types ###############
 
+
 class AddrFqdn(ExtraBaseModel):
     """IP address and/or FQDN."""
+
     ipAddr: IPvAnyAddress
     fqdn: str = Field(None, description="Indicates an FQDN.")
 
+
 class SvcExperience(ExtraBaseModel):
-    """Contains a mean opinion score with the customized range. """
+    """Contains a mean opinion score with the customized range."""
+
     mos: float
     upperRange: float
     lowerRange: float
+
 
 ###############################################
 
 ############### TS 29.508 Types ###############
 
+
 class UpfInformation(ExtraBaseModel):
     """Represents the ID/address/FQDN of the UPF."""
+
     upfId: str
     upfAddr: AddrFqdn
 
+
 class NotificationMethod(str, Enum):
-    periodic = "PERIODIC" 
-    oneTime = "ONE_TIME" 
-    onEventDetection = "ON_EVENT_DETECTION" 
+    periodic = "PERIODIC"
+    oneTime = "ONE_TIME"
+    onEventDetection = "ON_EVENT_DETECTION"
+
 
 ###############################################
 
 ############### TS 29.523 Types ###############
 
+
 class ReportingInformation(ExtraBaseModel):
     """Represents the type of reporting that the subscription requires."""
+
     immRep: bool
     notifMethod: NotificationMethod
     maxReportNbr: int = Field(None, description="", ge=0)
     monDur: datetime
     repPeriod: int = Field(None, description="", ge=0)
     sampRatio: int = Field(None, description="Expressed in percent.", ge=1, le=100)
-    partitionCriteria: List[PartitioningCriteria] = Field(None, description="",min_items=1)
+    partitionCriteria: List[PartitioningCriteria] = Field(
+        None, description="", min_items=1
+    )
     grpRepTime: int = Field(None, description="", ge=0)
     notifFlag: NotificationFlag
+
 
 ###############################################
 
 
 ############### TS 29.503 Types ###############
 
+
 class SuggestedPacketNumDl(ExtraBaseModel):
     suggestedPacketNumDl: int = Field(None, description="", ge=1)
     validityTime: datetime
 
+
 class ExpectedUeBehaviourData(ExtraBaseModel):
     """IP address and/or FQDN."""
-    #TODO: should be a map
+
+    # TODO: should be a map
     suggestedPacketNumDlList: List[SuggestedPacketNumDl]
     threeGppChargingCharacteristics: str
-    supportedFeatures:  constr(regex=r'^[A-Fa-f0-9]*$')
+    supportedFeatures: constr(regex=r"^[A-Fa-f0-9]*$")
+
 
 ###############################################
 
 ############### TS 29.554 Types ###############
 
+
 class NetworkAreaInfo(ExtraBaseModel):
-    """Describes a network area information in which the NF service consumer requests the number of UEs. """
-    ecgis: List[Ecgi] = Field(None, description="Contains a list of E-UTRA cell identities.", min_items=1)
-    ncgis: List[Ncgi] = Field(None, description="Contains a list of NR cell identities.", min_items=1)
-    gRanNodeIds: List[GlobalRanNodeId] = Field(None, description="Contains a list of NG RAN nodes.", min_items=1)
-    tais: List[Tai] = Field(None, description="Contains a list of tracking area identities.", min_items=1)
-    
+    """Describes a network area information in which the NF service consumer requests the number of UEs."""
+
+    ecgis: List[Ecgi] = Field(
+        None, description="Contains a list of E-UTRA cell identities.", min_items=1
+    )
+    ncgis: List[Ncgi] = Field(
+        None, description="Contains a list of NR cell identities.", min_items=1
+    )
+    gRanNodeIds: List[GlobalRanNodeId] = Field(
+        None, description="Contains a list of NG RAN nodes.", min_items=1
+    )
+    tais: List[Tai] = Field(
+        None, description="Contains a list of tracking area identities.", min_items=1
+    )
+
+
 ###############################################
 
 ############### TS 29.512 Types ###############
 
+
 class FlowDirection(str, Enum):
-    downlink = "DOWNLINK" 
-    uplink = "UPLINK" 
-    bidirectional = "BIDIRECTIONAL" 
+    downlink = "DOWNLINK"
+    uplink = "UPLINK"
+    bidirectional = "BIDIRECTIONAL"
     unspecified = "UNSPECIFIED"
+
 
 ###############################################
 
 ############### TS 29.514 Types ###############
 
+
 class EthFlowDescription(ExtraBaseModel):
     """Identifies an Ethernet flow."""
-    destMacAddr: constr(regex=r'^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$')
+
+    destMacAddr: constr(regex=r"^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$")
     ethType: str
     fDesc: str = Field(None, description="Defines a packet filter of an IP flow.")
     fDir: FlowDirection
-    sourceMacAddr: constr(regex=r'^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$')
+    sourceMacAddr: constr(regex=r"^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$")
     vlanTags: List[str] = Field(None, description="", min_items=1, max_items=2)
-    srcMacAddrEnd: constr(regex=r'^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$')
-    destMacAddrEnd: constr(regex=r'^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$')
+    srcMacAddrEnd: constr(regex=r"^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$")
+    destMacAddrEnd: constr(regex=r"^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$")
+
 
 ###############################################
 
 
 ############### TS 29.520 Types ###############
 
+
 class NetworkPerfType(str, Enum):
-    gnbActiveRatio = "GNB_ACTIVE_RATIO" 
-    gnbComputingUsage = "GNB_COMPUTING_USAGE" 
-    gnbMemoryUsage = "GNB_MEMORY_USAGE" 
-    gnbDiskUsage = "GNB_DISK_USAGE" 
-    numOfUE = "NUM_OF_UE" 
-    sessSuccRatio = "SESS_SUCC_RATIO" 
-    hoSuccRatio = "HO_SUCC_RATIO" 
+    gnbActiveRatio = "GNB_ACTIVE_RATIO"
+    gnbComputingUsage = "GNB_COMPUTING_USAGE"
+    gnbMemoryUsage = "GNB_MEMORY_USAGE"
+    gnbDiskUsage = "GNB_DISK_USAGE"
+    numOfUE = "NUM_OF_UE"
+    sessSuccRatio = "SESS_SUCC_RATIO"
+    hoSuccRatio = "HO_SUCC_RATIO"
+
 
 class ExceptionId(str, Enum):
-    unexpectedUELocation = "UNEXPECTED_UE_LOCATION" 
-    unexpectedLongLiveFlow = "UNEXPECTED_LONG_LIVE_FLOW" 
-    unexpectedLargeRateFlow = "UNEXPECTED_LARGE_RATE_FLOW" 
-    unexpectedWakeup= "UNEXPECTED_WAKEUP" 
-    suspecionOfDdosAttack = "SUSPICION_OF_DDOS_ATTACK" 
-    wrongDestinationAddress = "WRONG_DESTINATION_ADDRESS" 
-    tooFrequentServiceAccess = "TOO_FREQUENT_SERVICE_ACCESS" 
-    unexpectedRatioLinkFailures = "UNEXPECTED_RADIO_LINK_FAILURES" 
+    unexpectedUELocation = "UNEXPECTED_UE_LOCATION"
+    unexpectedLongLiveFlow = "UNEXPECTED_LONG_LIVE_FLOW"
+    unexpectedLargeRateFlow = "UNEXPECTED_LARGE_RATE_FLOW"
+    unexpectedWakeup = "UNEXPECTED_WAKEUP"
+    suspecionOfDdosAttack = "SUSPICION_OF_DDOS_ATTACK"
+    wrongDestinationAddress = "WRONG_DESTINATION_ADDRESS"
+    tooFrequentServiceAccess = "TOO_FREQUENT_SERVICE_ACCESS"
+    unexpectedRatioLinkFailures = "UNEXPECTED_RADIO_LINK_FAILURES"
     pingPongAcrossCells = "PING_PONG_ACROSS_CELLS"
 
+
 class ExceptionTrend(str, Enum):
-    up = "UP" 
-    down = "DOWN" 
-    unknow = "UNKNOW" 
+    up = "UP"
+    down = "DOWN"
+    unknow = "UNKNOW"
     stable = "STABLE"
 
+
 class DispersionClass(str, Enum):
-    fixed = "FIXED" 
-    camper = "CAMPER" 
-    traveller = "TRAVELLER" 
+    fixed = "FIXED"
+    camper = "CAMPER"
+    traveller = "TRAVELLER"
     topHeavy = "TOP_HEAVY"
 
+
 class CongestionType(str, Enum):
-    userPlane = "USER_PLANE" 
-    controlPlane = "CONTROL_PLANE" 
-    userAndControlPlane = "USER_AND_CONTROL_PLANE" 
+    userPlane = "USER_PLANE"
+    controlPlane = "CONTROL_PLANE"
+    userAndControlPlane = "USER_AND_CONTROL_PLANE"
+
 
 class TimeUnit(str, Enum):
-    minute = "MINUTE" 
-    hour = "HOUR" 
-    day = "DAY" 
+    minute = "MINUTE"
+    hour = "HOUR"
+    day = "DAY"
+
 
 class DispersionType(str, Enum):
-    dvda = "DVDA" 
-    tda = "TDA" 
-    dvdaAndTda = "DVDA_AND_TDA" 
+    dvda = "DVDA"
+    tda = "TDA"
+    dvdaAndTda = "DVDA_AND_TDA"
+
 
 class ServiceExperienceType(str, Enum):
-    voice = "VOICE" 
-    video = "VIDEO" 
-    other = "OTHER" 
+    voice = "VOICE"
+    video = "VIDEO"
+    other = "OTHER"
+
 
 class MatchingDirection(str, Enum):
-    ascending = "ASCENDING" 
-    descending = "DESCENDING" 
-    crossed = "CROSSED" 
+    ascending = "ASCENDING"
+    descending = "DESCENDING"
+    crossed = "CROSSED"
+
 
 class DispersionOrderingCriterion(str, Enum):
-    timeSlotStart = "TIME_SLOT_START" 
-    dispersion = "DISPERSION" 
-    classification = "CLASSIFICATION" 
-    ranking = "RANKING" 
+    timeSlotStart = "TIME_SLOT_START"
+    dispersion = "DISPERSION"
+    classification = "CLASSIFICATION"
+    ranking = "RANKING"
     percentileRanking = "PERCENTILE_RANKING"
 
+
 class ExpectedAnalyticsType(str, Enum):
-    mobility = "MOBILITY" 
-    commun = "COMMUN" 
+    mobility = "MOBILITY"
+    commun = "COMMUN"
     mobilityAndCommun = "MOBILITY_AND_COMMUN"
 
+
 class DnPerfOrderingCriterion(str, Enum):
-    avgTrafficRate = "AVERAGE_TRAFFIC_RATE" 
-    macTrafficRate = "MAXIMUM_TRAFFIC_RATE" 
-    avgPacketDelay = "AVERAGE_PACKET_DELAY" 
-    maxPacketDelay = "MAXIMUM_PACKET_DELAY" 
+    avgTrafficRate = "AVERAGE_TRAFFIC_RATE"
+    macTrafficRate = "MAXIMUM_TRAFFIC_RATE"
+    avgPacketDelay = "AVERAGE_PACKET_DELAY"
+    maxPacketDelay = "MAXIMUM_PACKET_DELAY"
     avgPacketLossRate = "AVERAGE_PACKET_LOSS_RATE"
 
+
 class Accuracy(str, Enum):
-    low = "LOW" 
+    low = "LOW"
     high = "HIGH"
 
+
 class AnalyticsMetadata(str, Enum):
-    numOfSamples = "NUM_OF_SAMPLES" 
-    dataWindow = "DATA_WINDOW" 
-    dataStatProps = "DATA_STAT_PROPS" 
-    strategy = "STRATEGY" 
+    numOfSamples = "NUM_OF_SAMPLES"
+    dataWindow = "DATA_WINDOW"
+    dataStatProps = "DATA_STAT_PROPS"
+    strategy = "STRATEGY"
     accuracy = "ACCURACY"
 
+
 class DatasetStatisticalProperty(str, Enum):
-    uniformDistData = "UNIFORM_DIST_DATA" 
+    uniformDistData = "UNIFORM_DIST_DATA"
     noOutliers = "NO_OUTLIERS"
 
+
 class OutputStrategy(str, Enum):
-    binary = "BINARY" 
+    binary = "BINARY"
     gradient = "GRADIENT"
 
+
 class NwdafFailureCode(str, Enum):
-    unavailableData = "UNAVAILABLE_DATA" 
+    unavailableData = "UNAVAILABLE_DATA"
     bothStatPredNotAllowed = "BOTH_STAT_PRED_NOT_ALLOWED"
-    unsatisfiedRequestedAnalyticsTime = "UNSATISFIED_REQUESTED_ANALYTICS_TIME" 
+    unsatisfiedRequestedAnalyticsTime = "UNSATISFIED_REQUESTED_ANALYTICS_TIME"
     other = "OTHER"
+
 
 class RetainabilityThreshold(ExtraBaseModel):
     """Represents a QoS flow retainability threshold."""
+
     relFlowNum: int = Field(None, description="", ge=0)
     relTimeUnit: TimeUnit
-    relFlowRatio:  int = Field(None, description="Expressed in percent", ge=1, le=100)
+    relFlowRatio: int = Field(None, description="Expressed in percent", ge=1, le=100)
+
 
 class ThresholdLevel(ExtraBaseModel):
     """Represents a threshold level."""
+
     congLevel: int
     nfLoadLevel: int
     nfCpuUsage: int
     nfMemoryUsage: int
     nfStorageUsage: int
-    avgTrafficRate: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
-    maxTrafficRate: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
+    avgTrafficRate: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+    maxTrafficRate: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
     avgPacketDelay: int = Field(None, description="Expressed in milliseconds.", ge=1)
     maxPacketDelay: int = Field(None, description="Expressed in milliseconds.", ge=1)
-    avgPacketLossRate: int = Field(None, description="Expressed in tenth of percent", ge=0, le=1000)
+    avgPacketLossRate: int = Field(
+        None, description="Expressed in tenth of percent", ge=0, le=1000
+    )
     svcExpLevel: float
 
+
 class TopApplication(ExtraBaseModel):
-    """Top application that contributes the most to the traffic. """
+    """Top application that contributes the most to the traffic."""
+
     appId: str = Field(None, description="String providing an application identifier.")
     ipTrafficFilter: FlowInfo
-    ratio: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
+    ratio: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+
 
 class Exception(ExtraBaseModel):
     """Represents the Exception information."""
+
     excepId: ExceptionId
     excepLevel: int
     excepTrend: ExceptionTrend
 
+
 class IpEthFlowDescription(ExtraBaseModel):
     """Contains the description of an Uplink and/or Downlink Ethernet flow."""
-    ipTrafficFilter: str = Field(None, description="Defines a packet filter of an IP flow.")
+
+    ipTrafficFilter: str = Field(
+        None, description="Defines a packet filter of an IP flow."
+    )
     ethTrafficFilter: EthFlowDescription
+
 
 class AddressList(ExtraBaseModel):
     """Represents a list of IPv4 and/or IPv6 addresses."""
-    ipv4Addrs: List[IPvAnyAddress] = Field(None, description="String identifying an Ipv4 address", min_items=1)
-    ipv6Addrs: List[IPvAnyAddress] = Field(None, description="String identifying an Ipv6 address", min_items=1)
+
+    ipv4Addrs: List[IPvAnyAddress] = Field(
+        None, description="String identifying an Ipv4 address", min_items=1
+    )
+    ipv6Addrs: List[IPvAnyAddress] = Field(
+        None, description="String identifying an Ipv6 address", min_items=1
+    )
+
 
 class CircumstanceDescription(ExtraBaseModel):
     """Contains the description of a circumstance."""
+
     freq: float
     tm: datetime
     locArea: NetworkAreaInfo
-    vol: int = Field(None, description=" Unsigned integer identifying a volume in units of bytes.", ge=0)
+    vol: int = Field(
+        None,
+        description=" Unsigned integer identifying a volume in units of bytes.",
+        ge=0,
+    )
+
 
 class AdditionalMeasurement(ExtraBaseModel):
     """Represents additional measurement information."""
+
     unexpLoc: NetworkAreaInfo
     unexpFlowTeps: List[IpEthFlowDescription] = Field(None, description="", min_items=1)
     unexpWakes: List[datetime] = Field(None, description="", min_items=1)
@@ -266,32 +360,53 @@ class AdditionalMeasurement(ExtraBaseModel):
     wrgDest: AddressList
     circums: List[CircumstanceDescription] = Field(None, description="", min_items=1)
 
+
 class TrafficCharacterization(ExtraBaseModel):
     """Identifies the detailed traffic characterization."""
-    dnn: str = Field("province1.mnc01.mcc202.gprs", description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
+
+    dnn: str = Field(
+        "province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
     snssai: Snssai
     appId: str = Field("", description="String providing an application identifier.")
-    fDescs: List[IpEthFlowDescription] = Field(None, description="", min_items=1, max_items=2)
-    ulVol: int = Field(None, description=" Unsigned integer identifying a volume in units of bytes.", ge=0)
+    fDescs: List[IpEthFlowDescription] = Field(
+        None, description="", min_items=1, max_items=2
+    )
+    ulVol: int = Field(
+        None,
+        description=" Unsigned integer identifying a volume in units of bytes.",
+        ge=0,
+    )
     ulVolVariance: float
-    dlVol: int = Field(None, description=" Unsigned integer identifying a volume in units of bytes.", ge=0)
+    dlVol: int = Field(
+        None,
+        description=" Unsigned integer identifying a volume in units of bytes.",
+        ge=0,
+    )
     dlVolVariance: float
 
+
 class AppListForUeComm(ExtraBaseModel):
-    """Represents the analytics of the application list used by UE. """
+    """Represents the analytics of the application list used by UE."""
+
     appId: str = Field("", description="String providing an application identifier.")
     startTime: datetime
     appDur: int = Field(None, description="", ge=0)
     occurRatio: int = Field(None, description="Expressed in percent", ge=1, le=100)
     spatialValidity: NetworkAreaInfo
 
+
 class SessInactTimerForUeComm(ExtraBaseModel):
     """Represents the N4 Session inactivity timer."""
+
     n4SessId: int = Field(None, description="", ge=0, le=255)
     sessInactiveTimer: int = Field(None, description="", ge=0)
 
+
 class UeCommunication(ExtraBaseModel):
     """Represents UE communication information."""
+
     commDur: int = Field(None, description="", ge=0)
     commDurVariance: float
     perioTime: int = Field(None, description="", ge=0)
@@ -306,17 +421,25 @@ class UeCommunication(ExtraBaseModel):
     anaOfAppList: AppListForUeComm
     sessInactTimer: SessInactTimerForUeComm
 
+
 class ApplicationVolume(ExtraBaseModel):
     """ApplicationVolume"""
+
     appId: str = Field(None, description="String providing an application identifier.")
     appVolume: int = Field(None, description="", ge=0)
 
+
 class DispersionCollection(ExtraBaseModel):
     """Dispersion collection per UE location or per slice."""
+
     ueLoc: UserLocation
     snssai: Snssai
-    supis: List[constr(regex=r'^(imsi-[0-9]{5,15}|nai-.+|gci-.+|gli-.+|.+)$')] = Field(None, description="", min_items=1)
-    gpsis: List[constr(regex=r'^(msisdn-[0-9]{5,15}|extid-.+@.+|.+)$')] = Field(None, description="", min_items=1)
+    supis: List[constr(regex=r"^(imsi-[0-9]{5,15}|nai-.+|gci-.+|gli-.+|.+)$")] = Field(
+        None, description="", min_items=1
+    )
+    gpsis: List[constr(regex=r"^(msisdn-[0-9]{5,15}|extid-.+@.+|.+)$")] = Field(
+        None, description="", min_items=1
+    )
     appVolumes: List[ApplicationVolume] = Field(None, description="", min_items=1)
     disperAmount: int = Field(None, description="", ge=0)
     disperClass: DispersionClass
@@ -325,36 +448,53 @@ class DispersionCollection(ExtraBaseModel):
     ueRatio: int = Field(None, description="", ge=1, le=100)
     confidence: int = Field(None, description="", ge=0)
 
+
 class DispersionInfo(ExtraBaseModel):
-    """Represents the Dispersion information. When subscribed event is "DISPERSION", the 
- "disperInfos" attribute shall be included."""
+    """Represents the Dispersion information. When subscribed event is "DISPERSION", the
+    "disperInfos" attribute shall be included."""
+
     tsStart: datetime
     tsDuration: int = Field(None, description="", ge=0)
-    disperCollects: List[DispersionCollection] = Field(None, description="", min_items=1)
+    disperCollects: List[DispersionCollection] = Field(
+        None, description="", min_items=1
+    )
     disperType = DispersionType
+
 
 class PerfData(ExtraBaseModel):
     """Represents DN performance data."""
-    avgTrafficRate: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
-    maxTrafficRate: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
+
+    avgTrafficRate: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+    maxTrafficRate: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
     avePacketDelay: int = Field(None, description="Expressed in milliseconds.", ge=1)
     maxPacketDelay: int = Field(None, description="Expressed in milliseconds.", ge=1)
-    avgPacketLossRate: int = Field(None, description="Expressed in tenth of percent.", ge=0, le=1000)
-    
+    avgPacketLossRate: int = Field(
+        None, description="Expressed in tenth of percent.", ge=0, le=1000
+    )
+
 
 class DnPerf(ExtraBaseModel):
-    """ Represents DN performance for the application."""
+    """Represents DN performance for the application."""
+
     appServerInsAddr: AddrFqdn
     upfInfo: UpfInformation
-    dnai: str = Field(None, description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.")
+    dnai: str = Field(
+        None,
+        description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.",
+    )
     perfData: PerfData
     spatialValidCon: NetworkAreaInfo
     temporalValidCon: TimeWindow
 
+
 class DnPerfInfo(ExtraBaseModel):
     """Represents DN performance information."""
+
     appId: str = Field(None, description="String providing an application identifier.")
-    dnn: Optional[str] = Field("province1.mnc01.mcc202.gprs", description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
+    dnn: Optional[str] = Field(
+        "province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
     snssai: Snssai
     dnPerf: List[DnPerf] = Field(None, description="", min_items=1)
     confidence: int = Field(None, description="", ge=0)
@@ -362,95 +502,136 @@ class DnPerfInfo(ExtraBaseModel):
 
 class LocationInfo(ExtraBaseModel):
     """Represents UE location information."""
+
     loc: UserLocation
     ratio: int = Field(None, description="Expressed in percent.", ge=1, le=100)
     confidence: int = Field(None, description="", ge=0)
 
+
 class RatFreqInformation(ExtraBaseModel):
     """Represents the RAT type and/or Frequency information."""
-    allFreq: Optional[bool] = Field(False, description="Set to true to indicate to handle all the frequencies the NWDAF received, otherwise set to false or omit. The allFreq attribute and the freq attribute are mutually exclusive.")
-    allRat: Optional[bool] = Field(False, description="Set to true to indicate to handle all the RAT Types the NWDAF received, otherwise set to false or omit. The allRat attribute and the ratType attribute are mutually exclusive. ")
+
+    allFreq: Optional[bool] = Field(
+        False,
+        description="Set to true to indicate to handle all the frequencies the NWDAF received, otherwise set to false or omit. The allFreq attribute and the freq attribute are mutually exclusive.",
+    )
+    allRat: Optional[bool] = Field(
+        False,
+        description="Set to true to indicate to handle all the RAT Types the NWDAF received, otherwise set to false or omit. The allRat attribute and the ratType attribute are mutually exclusive. ",
+    )
     freq: Optional[int] = Field(None, description="", ge=0, le=3279165)
     ratType: Optional[RatType]
     svcExpThreshold: ThresholdLevel
     matchingDir: MatchingDirection
 
+
 class ServiceExperienceInfo(ExtraBaseModel):
-    """ Represents service experience information."""
+    """Represents service experience information."""
+
     svcExprc: SvcExperience
     svcExprcVariance: float
-    supis: List[constr(regex=r'^(imsi-[0-9]{5,15}|nai-.+|gci-.+|gli-.+|.+)$')] = Field(None, description="", min_items=1)
+    supis: List[constr(regex=r"^(imsi-[0-9]{5,15}|nai-.+|gci-.+|gli-.+|.+)$")] = Field(
+        None, description="", min_items=1
+    )
     snssai: Snssai
     appId: str = Field("", description="String providing an application identifier.")
     srvExpcType: ServiceExperienceType
     ueLocs: List[LocationInfo] = Field(None, description="", min_items=1)
     upfInfo: UpfInformation
-    dnai: str = Field(None, description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.")
+    dnai: str = Field(
+        None,
+        description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.",
+    )
     appServerInst: AddrFqdn
     confidence: int = Field(None, description="", ge=0)
-    dnn: Optional[str] = Field("province1.mnc01.mcc202.gprs", description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
+    dnn: Optional[str] = Field(
+        "province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
     networkArea: NetworkAreaInfo
-    nsiId: str = Field(None, description="Contains the Identifier of the selected Network Slice instance.")
+    nsiId: str = Field(
+        None,
+        description="Contains the Identifier of the selected Network Slice instance.",
+    )
     ratio: int = Field(None, description="Expressed in percent.", ge=1, le=100)
     ratFreq: RatFreqInformation
 
+
 class ClassCriterion(ExtraBaseModel):
     """Indicates the dispersion class criterion for fixed, camper and/or traveller UE, and/or the top-heavy UE dispersion class criterion."""
+
     disperClass: DispersionClass
     classThreshold: int = Field(None, description="Expressed in percent.", ge=1, le=100)
     thresMatch: MatchingDirection
 
+
 class RankingCriterion(ExtraBaseModel):
-    """ Indicates the usage ranking criterion between the high, medium and low usage UE."""
+    """Indicates the usage ranking criterion between the high, medium and low usage UE."""
+
     highBase: int = Field(None, description="Expressed in percent.", ge=1, le=100)
     lowBase: int = Field(None, description="Expressed in percent.", ge=1, le=100)
 
+
 class DispersionRequirement(ExtraBaseModel):
     """Represents the dispersion analytics requirements."""
+
     disperType: DispersionType
     classCriters: List[ClassCriterion] = Field(None, description="", min_items=1)
     rankCriters: List[RankingCriterion] = Field(None, description="", min_items=1)
     dispOrderCriter: DispersionOrderingCriterion
     order: MatchingDirection
 
+
 class NsiIdInfo(ExtraBaseModel):
     """Represents the S-NSSAI and the optionally associated Network Slice Instance(s)."""
+
     snssai: Snssai
     nsiIds: List[str] = Field(None, description="", min_items=1)
 
+
 class QosRequirement(ExtraBaseModel):
     """Represents the QoS requirements."""
+
     fiveqi: int = Field(None, description="", ge=0, le=255)
-    gfbrUl: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
-    gfbrDl: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
+    gfbrUl: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+    gfbrDl: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
     resType: QosResourceType
     pdb: int = Field(None, description="Expressed in milliseconds.", ge=1)
-    per: constr(regex=r'^([0-9]E-[0-9])$')
+    per: constr(regex=r"^([0-9]E-[0-9])$")
+
 
 class DnPerformanceReq(ExtraBaseModel):
-    """ Represents other DN performance analytics requirements."""
+    """Represents other DN performance analytics requirements."""
+
     dnPerfOrderCriter: DnPerfOrderingCriterion
     order: MatchingDirection
     reportThresholds: List[ThresholdLevel] = Field(None, description="", min_items=1)
 
+
 class BwRequirement(ExtraBaseModel):
     """Represents bandwidth requirements."""
+
     appId: str = Field(None, description="String providing an application identifier.")
-    marBwDl: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
-    marBwUl: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
-    mirBwDl: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
-    mirBwUl: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
+    marBwDl: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+    marBwUl: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+    mirBwDl: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+    mirBwUl: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
+
 
 class AnalyticsMetadataIndication(ExtraBaseModel):
     """Contains analytics metadata information requested to be used during analytics generation."""
+
     dataWindow: TimeWindow
-    dataStatProps: List[DatasetStatisticalProperty] = Field(None, description="", min_items=1)
+    dataStatProps: List[DatasetStatisticalProperty] = Field(
+        None, description="", min_items=1
+    )
     strategy: OutputStrategy
     aggrNwdafIds: List[str] = Field(None, description="", min_items=1)
 
 
 class EventReportingRequirement(ExtraBaseModel):
     """Represents the type of reporting that the subscription requires."""
+
     accuracy: Accuracy
     accPerSubset: List[Accuracy] = Field(None, description="", min_items=1)
     startTs: datetime
@@ -463,29 +644,34 @@ class EventReportingRequirement(ExtraBaseModel):
     anaMeta: List[AnalyticsMetadata] = Field(None, description="", min_items=1)
     anaMetaInd: AnalyticsMetadataIndication
 
+
 class NetworkPerfRequirement(ExtraBaseModel):
     """Represents a network performance requirement."""
+
     nwPerfType: NetworkPerfType
     relativeRatio: int = Field(None, description="Expressed in percent.", ge=1, le=100)
     absoluteNum: int = Field(None, description="", ge=0)
 
+
 ###############################################
 
+
 class AnalyticsFailureCode(str, Enum):
-    unavailableData = "UNAVAILABLE_DATA" 
-    bothStatPredNotAllowed = "BOTH_STAT_PRED_NOT_ALLOWED" 
-    unsatifiedRequestAnalyticsTime = "UNSATISFIED_REQUESTED_ANALYTICS_TIME" 
-    other = "OTHER" 
+    unavailableData = "UNAVAILABLE_DATA"
+    bothStatPredNotAllowed = "BOTH_STAT_PRED_NOT_ALLOWED"
+    unsatifiedRequestAnalyticsTime = "UNSATISFIED_REQUESTED_ANALYTICS_TIME"
+    other = "OTHER"
+
 
 class AnalyticsEvent(str, Enum):
-    ueMobility = "UE_MOBILITY" 
-    ueComm = "UE_COMM" 
-    abnormalBehavior = "ABNORMAL_BEHAVIOR" 
-    congestion = "CONGESTION" 
-    networkPerformance = "NETWORK_PERFORMANCE" 
-    qosSustainability = "QOS_SUSTAINABILITY" 
-    dispersion = "DISPERSION" 
-    dnPerformance = "DN_PERFORMANCE" 
+    ueMobility = "UE_MOBILITY"
+    ueComm = "UE_COMM"
+    abnormalBehavior = "ABNORMAL_BEHAVIOR"
+    congestion = "CONGESTION"
+    networkPerformance = "NETWORK_PERFORMANCE"
+    qosSustainability = "QOS_SUSTAINABILITY"
+    dispersion = "DISPERSION"
+    dnPerformance = "DN_PERFORMANCE"
     serviceExperience = "SERVICE_EXPERIENCE"
 
 
@@ -548,34 +734,31 @@ class UeLocationInfo(ExtraBaseModel):
     geoDistrInfos: Optional[List[GeoDistributionInfo]] = Field(None, min_items=1)
 
 
-class UeMobilityExposure(ExtraBaseModel):
-    """Represents a UE mobility information."""
-    ts: datetime
-    recurringTime: ScheduledCommunicationTime
-    duration: int = Field(None, description="", ge = 0)
-    durationVariance: float
-    locInfo: List[UeLocationInfo] = Field(None, description="", min_items=1)
-
 class AnalyticsFailureEventInfo(ExtraBaseModel):
-    """Represents an event for which the subscription request was not successful 
-and including the associated failure reason. """
+    """Represents an event for which the subscription request was not successful
+    and including the associated failure reason."""
+
     event: AnalyticsEvent
     failureCode: AnalyticsFailureCode
 
+
 class QosSustainabilityExposure(ExtraBaseModel):
     """Represents a QoS sustainability information."""
-    #TODO: LocationArea5G
+
+    # TODO: LocationArea5G
     # locArea: LocationArea5G
     startTs: datetime
     endTs: datetime
     qosFlowRetThd: RetainabilityThreshold
-    ranUeThrouThd: constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')
+    ranUeThrouThd: constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")
     snssai: Snssai
     confidence: int = Field(None, description="", ge=0)
 
+
 class CongestionAnalytics(ExtraBaseModel):
-    """Represents data congestion analytics for transfer over the user plane, 
- control plane or both."""
+    """Represents data congestion analytics for transfer over the user plane,
+    control plane or both."""
+
     cngType: CongestionType
     tmWdw: TimeWindow
     nsi: ThresholdLevel
@@ -583,55 +766,60 @@ class CongestionAnalytics(ExtraBaseModel):
     topAppListUl: List[TopApplication] = Field(None, description="", min_items=1)
     topAppListDl: List[TopApplication] = Field(None, description="", min_items=1)
 
+
 class CongestInfo(ExtraBaseModel):
     """Represents a UE's user data congestion information."""
+
     # locArea: LocationArea5G
     cngAnas: List[CongestionAnalytics] = Field(None, description="", min_items=1)
 
+
 class AbnormalExposure(ExtraBaseModel):
     """Represents a user's abnormal behavior information."""
-    #TODO: test this list
-    gpsis: List[constr(regex=r'^(msisdn-[0-9]{5,15}|extid-.+@.+|.+)$')] = Field(None, description="", min_items=1)
+
+    # TODO: test this list
+    gpsis: List[constr(regex=r"^(msisdn-[0-9]{5,15}|extid-.+@.+|.+)$")] = Field(
+        None, description="", min_items=1
+    )
     appId: str = Field(None, description="String providing an application identifier.")
-    dnn: Optional[str] = Field("province1.mnc01.mcc202.gprs", description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
+    dnn: Optional[str] = Field(
+        "province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
     snssai: Snssai
     excep: List[Exception]
     ratio: int = Field(None, description="Expressed in percent", ge=1, le=100)
     confidence: int = Field(None, description="", ge=0)
     addtMeasInfo: AdditionalMeasurement
 
+
 class NetworkPerfExposure(ExtraBaseModel):
     """Represents network performance information."""
+
     # locArea: LocationArea5G
     nwPerfType: NetworkPerfType
     relativeRatio: int = Field(None, description="Expressed in percent", ge=1, le=100)
     absoluteNum: int = Field(None, description="", ge=0)
     confidence: int = Field(None, description="", ge=0)
 
-class AnalyticsData(ExtraBaseModel):
-    """Represents analytics data."""
-    start: datetime
-    expiry: datetime
-    timeStampGen: datetime
-    ueMobilityInfos: List[UeMobilityExposure] = Field(None, description="", min_items=1)
-    ueCommInfos: List[UeCommunication] = Field(None, description="", min_items=1)
-    nwPerfInfos: List[NetworkPerfExposure] = Field(None, description="", min_items=1)
-    abnormalInfos: List[AbnormalExposure] = Field(None, description="", min_items=1)
-    congestInfos: List[CongestInfo] = Field(None, description="", min_items=1)
-    qosSustainInfos: List[QosSustainabilityExposure] = Field(None, description="", min_items=1)
-    disperInfos: List[DispersionInfo] = Field(None, description="", min_items=1)
-    dnPerfInfos: List[DnPerfInfo] = Field(None, description="", min_items=1)
-    svcExps: List[ServiceExperienceInfo] = Field(None, description="", min_items=1)
-    disperReqs: List[DispersionRequirement] = Field(None, description="", min_items=1)
-    suppFeat: constr(regex=r'^[A-Fa-f0-9]*$')
 
 class AnalyticsEventFilter(ExtraBaseModel):
-    """ Represents analytics event filter information."""
+    """Represents analytics event filter information."""
+
     # locArea: LocationArea5G
-    dnn: Optional[str] = Field("province1.mnc01.mcc202.gprs", description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
-    dnais: List[str] = Field(None, description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.", min_items=1)
+    dnn: Optional[str] = Field(
+        "province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
+    dnais: List[str] = Field(
+        None,
+        description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.",
+        min_items=1,
+    )
     nwPerfTypes: List[NetworkPerfType] = Field(None, description="", min_items=1)
-    appIds: List[str] = Field(None, description="String providing an application identifier.", min_items=1)
+    appIds: List[str] = Field(
+        None, description="String providing an application identifier.", min_items=1
+    )
     appIds: List[ExceptionId] = Field(None, description="", min_items=1)
     exptAnaType: ExpectedAnalyticsType
     exptUeBehav: ExpectedUeBehaviourData
@@ -641,47 +829,87 @@ class AnalyticsEventFilter(ExtraBaseModel):
     listOfAnaSubsets: List[AnalyticsSubset] = Field(None, description="", min_items=1)
     dnPerfReqs: List[DnPerformanceReq] = Field(None, description="", min_items=1)
     bwRequs: List[BwRequirement] = Field(None, description="", min_items=1)
-    ratFreqs: List[RatFreqInformation] = Field(None, description="", min_items=1)    
+    ratFreqs: List[RatFreqInformation] = Field(None, description="", min_items=1)
     appServerAddrs: List[AddrFqdn] = Field(None, description="", min_items=1)
     maxNumOfTopAppUl: int = Field(None, description="", ge=0)
     maxNumOfTopAppDl: int = Field(None, description="", ge=0)
     # visitedLocAreas: List[LocationArea5G] = Field(None, description="", min_items=1)
 
+
 class TargetUeId(ExtraBaseModel):
     """Represents the target UE(s) information."""
-    anyUeInd: bool
-    gpsi: constr(regex=r'^(msisdn-[0-9]{5,15}|extid-.+@.+|.+)$')
+
+    anyUeInd: Optional[bool]
+    gpsi: constr(regex=r"^(msisdn-[0-9]{5,15}|extid-.+@.+|.+)$")
     exterGroupId: str = Field("Group1@domain.com", description="")
+
+
+class UeMobilityExposure(ExtraBaseModel):
+    """Represents a UE mobility information."""
+
+    ts: Optional[datetime]
+    recurringTime: Optional[ScheduledCommunicationTime]
+    duration: int = Field(None, description="", ge=0)
+    durationVariance: Optional[float]
+    locInfo: List[UeLocationInfo] = Field(None, description="", min_items=1)
+
 
 class AnalyticsRequest(ExtraBaseModel):
     """Represents the parameters to request to retrieve analytics information."""
+
     analyEvent: AnalyticsEvent
-    analyEventFilter: AnalyticsEventFilter
-    analyRep: EventReportingRequirement
+    analyEventFilter: Optional[AnalyticsEventFilter]
+    analyRep: Optional[EventReportingRequirement]
     tgtUe: TargetUeId
-    suppFeat: constr(regex=r'^[A-Fa-f0-9]*$')
+    suppFeat: constr(regex=r"^[A-Fa-f0-9]*$")
+
+
+class AnalyticsData(ExtraBaseModel):
+    """Represents analytics data."""
+
+    start: Optional[datetime]
+    expiry: Optional[datetime]
+    timeStampGen: Optional[datetime]
+    ueMobilityInfos: List[UeMobilityExposure] = Field(None, description="", min_items=1)
+    ueCommInfos: List[UeCommunication] = Field(None, description="", min_items=1)
+    nwPerfInfos: List[NetworkPerfExposure] = Field(None, description="", min_items=1)
+    abnormalInfos: List[AbnormalExposure] = Field(None, description="", min_items=1)
+    congestInfos: List[CongestInfo] = Field(None, description="", min_items=1)
+    qosSustainInfos: List[QosSustainabilityExposure] = Field(
+        None, description="", min_items=1
+    )
+    disperInfos: List[DispersionInfo] = Field(None, description="", min_items=1)
+    dnPerfInfos: List[DnPerfInfo] = Field(None, description="", min_items=1)
+    svcExps: List[ServiceExperienceInfo] = Field(None, description="", min_items=1)
+    disperReqs: List[DispersionRequirement] = Field(None, description="", min_items=1)
+    suppFeat: constr(regex=r"^[A-Fa-f0-9]*$")
+
 
 class UeLocationInfo(ExtraBaseModel):
     """Represents a UE location information."""
-    # loc: LocationArea5G
+
+    loc: LocationArea5G
     ratio: int = Field(None, description="Expressed in percent", ge=1, le=100)
     confidence: int = Field(None, description="", ge=0)
 
-class UeMobilityExposure(ExtraBaseModel):
-    """ Represents a UE mobility information."""
-    ts: datetime
-    recurringTime: ScheduledCommunicationTime
-    duration: int = Field(None, description="", ge=0)
-    durationVariance: float
-    locInfo: List[UeLocationInfo] = Field(None, description="", min_items=1)
 
 class AnalyticsEventFilterSubsc(ExtraBaseModel):
     """Represents an analytics event filter."""
+
     nwPerfReqs: List[NetworkPerfRequirement] = Field(None, description="", min_items=1)
     # locArea: LocationArea5G
-    appIds: List[str] = Field(None, description="String providing an application identifier.")
-    dnn: Optional[str] = Field("province1.mnc01.mcc202.gprs", description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
-    dnais: List[str] = Field(None, description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.", min_items=1)
+    appIds: List[str] = Field(
+        None, description="String providing an application identifier."
+    )
+    dnn: Optional[str] = Field(
+        "province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
+    dnais: List[str] = Field(
+        None,
+        description="DNAI (Data network access identifier), see clause 5.6.7 of 3GPP TS 23.501.",
+        min_items=1,
+    )
     excepRequs: List[Exception] = Field(None, description="", min_items=1)
     exptAnaType: ExpectedAnalyticsType
     exptUeBehav: ExpectedUeBehaviourData
@@ -690,27 +918,37 @@ class AnalyticsEventFilterSubsc(ExtraBaseModel):
     snssai: Snssai
     nsiIdInfos: List[NsiIdInfo] = Field(None, description="", min_items=1)
     qosReq: QosRequirement
-    qosFlowRetThds: List[RetainabilityThreshold] = Field(None, description="", min_items=1)
-    ranUeThrouThds: List[constr(regex=r'^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$')] = Field(None, description="", min_items=1)
+    qosFlowRetThds: List[RetainabilityThreshold] = Field(
+        None, description="", min_items=1
+    )
+    ranUeThrouThds: List[constr(regex=r"^\d+(\.\d+)? (bps|Kbps|Mbps|Gbps|Tbps)$")] = (
+        Field(None, description="", min_items=1)
+    )
     disperReqs: List[DispersionRequirement] = Field(None, description="", min_items=1)
     listOfAnaSubsets: List[AnalyticsSubset] = Field(None, description="", min_items=1)
     dnPerfReqs: List[DnPerformanceReq] = Field(None, description="", min_items=1)
     bwRequs: List[BwRequirement] = Field(None, description="", min_items=1)
     ratFreqs: List[RatFreqInformation] = Field(None, description="", min_items=1)
     appServerAddrs: List[AddrFqdn] = Field(None, description="", min_items=1)
-    extraReportReq: List[EventReportingRequirement] = Field(None, description="", min_items=1)
+    extraReportReq: List[EventReportingRequirement] = Field(
+        None, description="", min_items=1
+    )
     maxNumOfTopAppUl: int = Field(None, description="", ge=0)
     maxNumOfTopAppDl: int = Field(None, description="", ge=0)
     # visitedLocAreas: List[LocationArea5G] = Field(None, description="", min_items=1)
 
+
 class AnalyticsEventSubsc(ExtraBaseModel):
     """Represents a subscribed analytics event."""
+
     analyEvent: AnalyticsEvent
     analyEventFilter: AnalyticsEventFilterSubsc
     tgtUe: TargetUeId
 
+
 class AnalyticsEventNotif(ExtraBaseModel):
     """Represents an analytics event to be reported."""
+
     analyEvent: AnalyticsEvent
     expiry: datetime
     timeStamp: datetime
@@ -721,32 +959,53 @@ class AnalyticsEventNotif(ExtraBaseModel):
     abnormalInfos: List[AbnormalExposure] = Field(None, description="", min_items=1)
     congestInfos: List[CongestInfo] = Field(None, description="", min_items=1)
     nwPerfInfos: List[NetworkPerfExposure] = Field(None, description="", min_items=1)
-    qosSustainInfos: List[QosSustainabilityExposure] = Field(None, description="", min_items=1)
+    qosSustainInfos: List[QosSustainabilityExposure] = Field(
+        None, description="", min_items=1
+    )
     disperInfos: List[DispersionInfo] = Field(None, description="", min_items=1)
     dnPerfInfos: List[DnPerfInfo] = Field(None, description="", min_items=1)
     svcExps: List[ServiceExperienceInfo] = Field(None, description="", min_items=1)
     start: datetime
     timeStampGen: datetime
 
+
 class AnalyticsEventNotification(ExtraBaseModel):
     """Represents an analytics event(s) notification."""
+
     notifId: str
-    analyEventNotifs: List[AnalyticsEventNotif] = Field(None, description="", min_items=1)
+    analyEventNotifs: List[AnalyticsEventNotif] = Field(
+        None, description="", min_items=1
+    )
+
 
 class AnalyticsExposureSubscCreate(ExtraBaseModel):
     """Represents an analytics exposure subscription."""
-    analyEventsSubs: List[AnalyticsEventSubsc] = Field(None, description="", min_items=1)
+
+    analyEventsSubs: List[AnalyticsEventSubsc] = Field(
+        None, description="", min_items=1
+    )
     analyRepInfo: ReportingInformation
     notifUri: str
     notifId: str
     eventNotifis: List[AnalyticsEventNotif] = Field(None, description="", min_items=1)
-    failEventReports: List[AnalyticsFailureEventInfo] = Field(None, description="", min_items=1)
-    suppFeat:  constr(regex=r'^[A-Fa-f0-9]*$')
-    requestTestNotification: bool = Field(None, description="Set to true by the AF to request the NEF to send a test notification as defined in clause 5.2.5.3 of 3GPP TS 29.122. Set to false or omitted otherwise.")
+    failEventReports: List[AnalyticsFailureEventInfo] = Field(
+        None, description="", min_items=1
+    )
+    suppFeat: constr(regex=r"^[A-Fa-f0-9]*$")
+    requestTestNotification: bool = Field(
+        None,
+        description="Set to true by the AF to request the NEF to send a test notification as defined in clause 5.2.5.3 of 3GPP TS 29.122. Set to false or omitted otherwise.",
+    )
     websockNotifConfig: WebsockNotifConfig
+
 
 class AnalyticsExposureSubsc(AnalyticsExposureSubscCreate):
     """Represents an analytics exposure subscription."""
-    link: Optional[AnyHttpUrl] = Field("https://myresource.com", description="String identifying a referenced resource. This is also returned as a location header in 201 Created Response")
+
+    link: Optional[AnyHttpUrl] = Field(
+        "https://myresource.com",
+        description="String identifying a referenced resource. This is also returned as a location header in 201 Created Response",
+    )
+
     class Config:
-            orm_mode = True
+        orm_mode = True

--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -1,7 +1,9 @@
-from typing import List, Optional, Union
 from datetime import datetime
-from pydantic import Field, IPvAnyAddress, AnyHttpUrl, confloat, conint, constr
 from enum import Enum
+from typing import Dict, List, Optional, Union
+
+from pydantic import AnyHttpUrl, AnyUrl, Field, IPvAnyAddress, confloat, conint, constr
+
 from .utils import ExtraBaseModel
 
 # Shared properties | used for request body in endpoint/items.py
@@ -310,9 +312,16 @@ class ApplicationlayerId(ExtraBaseModel):
     )
 
 
+class Mcc(ExtraBaseModel):
+    __root__: constr(regex=r"^\d{3}$") = Field(
+        ...,
+        description="Mobile Country Code part of the PLMN, comprising 3 digits, as defined in clause 9.3.3.5 of 3GPP TS 38.413. \n",
+    )
+
+
 class PlmnId(ExtraBaseModel):
-    mcc: int
-    mnc: int
+    mcc: Mcc
+    mnc: Mcc
 
 
 class Tai(ExtraBaseModel):
@@ -327,8 +336,23 @@ class Ecgi(ExtraBaseModel):
     nid: Optional[Nid] = None
 
 
-class SupportedGADShapes(Enum):
+class SupportedGADShapes(str, Enum):
     POINT = "POINT"
+    POINT_UNCERTAINTY_CIRCLE = "POINT_UNCERTAINTY_CIRCLE"
+    POINT_UNCERTAINTY_ELLIPSE = "POINT_UNCERTAINTY_ELLIPSE"
+    POLYGON = "POLYGON"
+    POINT_ALTITUDE = "POINT_ALTITUDE"
+    POINT_ALTITUDE_UNCERTAINTY = "POINT_ALTITUDE_UNCERTAINTY"
+    ELLIPSOID_ARC = "ELLIPSOID_ARC"
+    LOCAL_2D_POINT_UNCERTAINTY_ELLIPSE = "LOCAL_2D_POINT_UNCERTAINTY_ELLIPSE"
+    LOCAL_3D_POINT_UNCERTAINTY_ELLIPSOID = "LOCAL_3D_POINT_UNCERTAINTY_ELLIPSOID"
+    DISTANCE_DIRECTION = "DISTANCE_DIRECTION"
+    RELATIVE_2D_LOCATION_UNCERTAINTY_ELLIPSE = (
+        "RELATIVE_2D_LOCATION_UNCERTAINTY_ELLIPSE"
+    )
+    RELATIVE_3D_LOCATION_UNCERTAINTY_ELLIPSOID = (
+        "RELATIVE_3D_LOCATION_UNCERTAINTY_ELLIPSOID"
+    )
 
 
 class GADShape(ExtraBaseModel):
@@ -805,17 +829,34 @@ class LocationInfo(ExtraBaseModel):
 
 
 class MonitoringType(str, Enum):
-    locationReporting = "LOCATION_REPORTING"
-    lossOfConnectivity = "LOSS_OF_CONNECTIVITY"
-    ueReachability = "UE_REACHABILITY"
+    LOSS_OF_CONNECTIVITY = "LOSS_OF_CONNECTIVITY"
+    UE_REACHABILITY = "UE_REACHABILITY"
+    LOCATION_REPORTING = "LOCATION_REPORTING"
+    CHANGE_OF_IMSI_IMEI_ASSOCIATION = "CHANGE_OF_IMSI_IMEI_ASSOCIATION"
+    ROAMING_STATUS = "ROAMING_STATUS"
+    COMMUNICATION_FAILURE = "COMMUNICATION_FAILURE"
+    AVAILABILITY_AFTER_DDN_FAILURE = "AVAILABILITY_AFTER_DDN_FAILURE"
+    NUMBER_OF_UES_IN_AN_AREA = "NUMBER_OF_UES_IN_AN_AREA"
+    PDN_CONNECTIVITY_STATUS = "PDN_CONNECTIVITY_STATUS"
+    DOWNLINK_DATA_DELIVERY_STATUS = "DOWNLINK_DATA_DELIVERY_STATUS"
+    API_SUPPORT_CAPABILITY = "API_SUPPORT_CAPABILITY"
+    NUM_OF_REGD_UES = "NUM_OF_REGD_UES"
+    NUM_OF_ESTD_PDU_SESSIONS = "NUM_OF_ESTD_PDU_SESSIONS"
+    AREA_OF_INTEREST = "AREA_OF_INTEREST"
+    GROUP_MEMBER_LIST_CHANGE = "GROUP_MEMBER_LIST_CHANGE"
+    APPLICATION_START = "APPLICATION_START"
+    APPLICATION_STOP = "APPLICATION_STOP"
+    SESSION_INACTIVITY_TIME = "SESSION_INACTIVITY_TIME"
+    TRAFFIC_VOLUME = "TRAFFIC_VOLUME"
+    UL_DL_DATA_RATE = "UL_DL_DATA_RATE"
 
 
 class ReachabilityType(str, Enum):
-    sms = "SMS"
-    data = "DATA"
+    SMS = "SMS"
+    DATA = "DATA"
 
 
-class AssociationTypeModel(Enum):
+class AssociationTypeModel(str, Enum):
     IMEI = "IMEI"
     IMEISV = "IMEISV"
 
@@ -925,7 +966,7 @@ class PdnConnectionInformation(ExtraBaseModel):
     macAddrs: Optional[List[MacAddr48]] = Field(None, min_items=1)
 
 
-class DlDataDeliveryStatus(Enum):
+class DlDataDeliveryStatus(str, Enum):
     BUFFERED = "BUFFERED"
     TRANSMITTED = "TRANSMITTED"
     DISCARDED = "DISCARDED"
@@ -1139,3 +1180,342 @@ class MonitoringNotification(ExtraBaseModel):
 
 class MonitoringEventReportReceived(ExtraBaseModel):
     ok: bool
+
+
+class ExternalGroupId(ExtraBaseModel):
+    __root__: str = Field(
+        ...,
+        description='string containing a local identifier followed by "@" and a domain identifier. Both the local identifier and the domain identifier shall be encoded as strings that do not contain any "@" characters. See Clauses 4.6.2 and 4.6.3 of 3GPP TS 23.682 for more information.\n',
+    )
+
+
+class WebsockNotifConfig(ExtraBaseModel):
+    websocketUri: Optional[AnyUrl] = None
+    requestWebsocketUri: Optional[bool] = Field(
+        None,
+        description="Set by the SCS/AS to indicate that the Websocket delivery is requested.",
+    )
+
+
+class LocationType(str, Enum):
+    CURRENT_LOCATION = "CURRENT_LOCATION"
+    LAST_KNOWN_LOCATION = "LAST_KNOWN_LOCATION"
+    CURRENT_OR_LAST_KNOWN_LOCATION = "CURRENT_OR_LAST_KNOWN_LOCATION"
+    INITIAL_LOCATION = "INITIAL_LOCATION"
+
+
+class AccuracyModel(str, Enum):
+    CGI_ECGI = "CGI_ECGI"
+    ENODEB = "ENODEB"
+    TA_RA = "TA_RA"
+    PLMN = "PLMN"
+    TWAN_ID = "TWAN_ID"
+    GEO_AREA = "GEO_AREA"
+    CIVIC_ADDR = "CIVIC_ADDR"
+
+
+class ResponseTime(str, Enum):
+    LOW_DELAY = "LOW_DELAY"
+    DELAY_TOLERANT = "DELAY_TOLERANT"
+    NO_DELAY = "NO_DELAY"
+
+
+class LcsQosClass(str, Enum):
+    BEST_EFFORT = "BEST_EFFORT"
+    ASSURED = "ASSURED"
+    MULTIPLE_QOS = "MULTIPLE_QOS"
+
+
+class LocationQoS(ExtraBaseModel):
+    hAccuracy: Optional[Accuracy] = None
+    vAccuracy: Optional[Accuracy] = None
+    verticalRequested: Optional[bool] = None
+    responseTime: Optional[ResponseTime] = None
+    minorLocQoses: Optional[List[MinorLocationQoS]] = Field(
+        None, max_items=2, min_items=1
+    )
+    lcsQosClass: Optional[LcsQosClass] = None
+
+
+class LinearDistance(ExtraBaseModel):
+    __root__: conint(ge=1, le=10000) = Field(
+        ...,
+        description="Minimum straight line distance moved by a UE to trigger a motion event report.",
+    )
+
+
+class DateTime(ExtraBaseModel):
+    __root__: datetime = Field(
+        ..., description='string with format "date-time" as defined in OpenAPI.'
+    )
+
+
+class ServiceIdentity(ExtraBaseModel):
+    __root__: str = Field(..., description="Contains the service identity")
+
+
+class UpLocRepAddrAfRm1(BaseModel):
+    ipv4Addrs: List[Ipv4Addr] = Field(..., min_items=1)
+    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
+    fqdn: Optional[Fqdn] = None
+
+
+class UpLocRepAddrAfRm2(BaseModel):
+    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
+    ipv6Addrs: List[Ipv6Addr] = Field(..., min_items=1)
+    fqdn: Optional[Fqdn] = None
+
+
+class UpLocRepAddrAfRm3(BaseModel):
+    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
+    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
+    fqdn: Fqdn
+
+
+class UpLocRepAddrAfRm(BaseModel):
+    __root__: Optional[
+        Union[UpLocRepAddrAfRm1, UpLocRepAddrAfRm2, UpLocRepAddrAfRm3]
+    ] = Field(None, description="Represents the user plane addressing information.")
+
+
+class CodeWord(ExtraBaseModel):
+    __root__: str = Field(..., description="Contains the codeword")
+
+
+class NetworkAreaInfo(ExtraBaseModel):
+    ecgis: Optional[List[Ecgi]] = Field(
+        None, description="Contains a list of E-UTRA cell identities.", min_items=1
+    )
+    ncgis: Optional[List[Ncgi]] = Field(
+        None, description="Contains a list of NR cell identities.", min_items=1
+    )
+    gRanNodeIds: Optional[List[GlobalRanNodeId]] = Field(
+        None, description="Contains a list of NG RAN nodes.", min_items=1
+    )
+    tais: Optional[List[Tai]] = Field(
+        None, description="Contains a list of tracking area identities.", min_items=1
+    )
+
+
+class RelatedUeType(str, Enum):
+    LOCATED_UE = "LOCATED_UE"
+    REFERENCE_UE = "REFERENCE_UE"
+
+
+class RelatedUeModel(ExtraBaseModel):
+    applicationlayerId: ApplicationlayerId
+    relatedUeType: RelatedUeType
+
+
+class RangingSlResult(str, Enum):
+    ABSOLUTE_LOCATION = "ABSOLUTE_LOCATION"
+    RELATIVE_LOCATION = "RELATIVE_LOCATION"
+    RANGING_DIRECTION = "RANGING_DIRECTION"
+    RANGING = "RANGING"
+    DIRECTION = "DIRECTION"
+    VELOCITY = "VELOCITY"
+    RELATIVE_VELOCITY = "RELATIVE_VELOCITY"
+
+
+class IpAddr(ExtraBaseModel):
+    ipv4Addr: Optional[Ipv4Addr] = None
+    ipv6Addr: Optional[Ipv6Addr] = None
+    ipv6Prefix: Optional[Ipv6Prefix] = None
+
+
+class SubType(str, Enum):
+    AERIAL_UE = "AERIAL_UE"
+
+
+class UavPolicy(ExtraBaseModel):
+    uavMoveInd: bool
+    revokeInd: bool
+
+
+class SACRepFormat(str, Enum):
+    NUMERICAL = "NUMERICAL"
+    PERCENTAGE = "PERCENTAGE"
+
+
+class LocationArea5G(ExtraBaseModel):
+    geographicAreas: Optional[List[GeographicArea]] = Field(
+        None,
+        description="Identifies a list of geographic area of the user where the UE is located.",
+        min_items=0,
+    )
+    civicAddresses: Optional[List[CivicAddress]] = Field(
+        None,
+        description="Identifies a list of civic addresses of the user where the UE is located.",
+        min_items=0,
+    )
+    nwAreaInfo: Optional[NetworkAreaInfo] = None
+
+
+class LocationArea(ExtraBaseModel):
+    cellIds: Optional[List[str]] = Field(
+        None,
+        description="Indicates a list of Cell Global Identities of the user which identifies the cell the UE is registered.\n",
+        min_items=1,
+    )
+    enodeBIds: Optional[List[str]] = Field(
+        None,
+        description="Indicates a list of eNodeB identities in which the UE is currently located.",
+        min_items=1,
+    )
+    routingAreaIds: Optional[List[str]] = Field(
+        None,
+        description="Identifies a list of Routing Area Identities of the user where the UE is located.\n",
+        min_items=1,
+    )
+    trackingAreaIds: Optional[List[str]] = Field(
+        None,
+        description="Identifies a list of Tracking Area Identities of the user where the UE is located.\n",
+        min_items=1,
+    )
+    geographicAreas: Optional[List[GeographicArea]] = Field(
+        None,
+        description="Identifies a list of geographic area of the user where the UE is located.",
+        min_items=1,
+    )
+    civicAddresses: Optional[List[CivicAddress]] = Field(
+        None,
+        description="Identifies a list of civic addresses of the user where the UE is located.",
+        min_items=1,
+    )
+
+
+class VelocityRequested(str, Enum):
+    VELOCITY_IS_NOT_REQUESTED = "VELOCITY_IS_NOT_REQUESTED"
+    VELOCITY_IS_REQUESTED = "VELOCITY_IS_REQUESTED"
+
+
+class AgeOfLocationEstimate(ExtraBaseModel):
+    __root__: conint(ge=0, le=32767) = Field(
+        ..., description="Indicates value of the age of the location estimate."
+    )
+
+
+class TimeWindowModel(ExtraBaseModel):
+    startTime: DateTime
+    stopTime: DateTime
+
+class MonitoringEventSubscription(ExtraBaseModel):
+    self: Optional[AnyUrl] = None
+    supportedFeatures: Optional[SupportedFeatures] = None
+    mtcProviderId: Optional[str] = Field(
+        None, description="Identifies the MTC Service Provider and/or MTC Application."
+    )
+    appIds: Optional[List[str]] = Field(
+        None, description="Identifies the Application Identifier(s)", min_items=1
+    )
+    externalId: Optional[ExternalId] = None
+    msisdn: Optional[Msisdn] = None
+    addedExternalIds: Optional[List[ExternalId]] = Field(
+        None,
+        description="Indicates the added external Identifier(s) within the active group.",
+        min_items=1,
+    )
+    addedMsisdns: Optional[List[Msisdn]] = Field(
+        None,
+        description="Indicates the added MSISDN(s) within the active group.",
+        min_items=1,
+    )
+    excludedExternalIds: Optional[List[ExternalId]] = Field(
+        None,
+        description="Indicates cancellation of the external Identifier(s) within the active group.",
+        min_items=1,
+    )
+    excludedMsisdns: Optional[List[Msisdn]] = Field(
+        None,
+        description="Indicates cancellation of the MSISDN(s) within the active group.",
+        min_items=1,
+    )
+    externalGroupId: Optional[ExternalGroupId] = None
+    addExtGroupId: Optional[List[ExternalGroupId]] = Field(None, min_items=2)
+    ipv4Addr: Optional[Ipv4AddrModel] = None
+    ipv6Addr: Optional[Ipv6AddrModel] = None
+    dnn: Optional[Dnn] = None
+    notificationDestination: AnyUrl
+    requestTestNotification: Optional[bool] = Field(
+        None,
+        description="Set to true by the SCS/AS to request the SCEF to send a test notification as defined in clause 5.2.5.3. Set to false by the SCS/AS indicates not request SCEF to send a test notification, default false if omitted otherwise.\n",
+    )
+    websockNotifConfig: Optional[WebsockNotifConfig] = None
+    monitoringType: MonitoringType
+    maximumNumberOfReports: Optional[conint(ge=1)] = Field(
+        None,
+        description="Identifies the maximum number of event reports to be generated by the HSS, MME/SGSN as specified in clause 5.6.0 of 3GPP TS 23.682.\n",
+    )
+    monitorExpireTime: Optional[DateTime] = None
+    repPeriod: Optional[DurationSecModel] = None
+    groupReportGuardTime: Optional[DurationSecModel] = None
+    maximumDetectionTime: Optional[DurationSecModel] = None
+    reachabilityType: Optional[ReachabilityType] = None
+    maximumLatency: Optional[DurationSecModel] = None
+    maximumResponseTime: Optional[DurationSecModel] = None
+    suggestedNumberOfDlPackets: Optional[conint(ge=0)] = Field(
+        None,
+        description='If "monitoringType" is "UE_REACHABILITY", this parameter may be included to identify the number of packets that the serving gateway shall buffer in case that the UE is not reachable.\n',
+    )
+    idleStatusIndication: Optional[bool] = Field(
+        None,
+        description='If "monitoringType" is set to "UE_REACHABILITY" or "AVAILABILITY_AFTER_DDN_FAILURE", this parameter may be included to indicate the notification of when a UE, for which PSM is enabled, transitions into idle mode. "true"  indicates enabling of notification; "false"  indicate no need to notify. Default value is "false" if omitted.\n',
+    )
+    locationType: Optional[LocationType] = None
+    accuracy: Optional[AccuracyModel] = None
+    minimumReportInterval: Optional[DurationSecModel] = None
+    maxRptExpireIntvl: Optional[DurationSecModel] = None
+    samplingInterval: Optional[DurationSecModel] = None
+    reportingLocEstInd: Optional[bool] = Field(
+        None,
+        description='Indicates whether to request the location estimate for event reporting. If "monitoringType" is "LOCATION_REPORTING", this parameter may be included to indicate whether event reporting requires the location information. If set to true, the location estimation information shall be included in event reporting. If set to "false", indicates the location estimation information shall not be included in event reporting. Default "false" if omitted.\n',
+    )
+    linearDistance: Optional[LinearDistance] = None
+    locQoS: Optional[LocationQoS] = None
+    svcId: Optional[ServiceIdentity] = None
+    ldrType: Optional[LdrType] = None
+    velocityRequested: Optional[VelocityRequested] = None
+    maxAgeOfLocEst: Optional[AgeOfLocationEstimate] = None
+    locTimeWindow: Optional[TimeWindowModel] = None
+    supportedGADShapes: Optional[List[SupportedGADShapes]] = None
+    codeWord: Optional[CodeWord] = None
+    upLocRepIndAf: Optional[bool] = Field(
+        False,
+        description='Indicates whether location reporting over user plane is requested or not. "true" indicates the location reporting over user plane is requested. "false" indicates the location reporting over user plane is not requested. Default value is "false" if omitted.\n',
+    )
+    upLocRepAddrAf: Optional[UpLocRepAddrAfRm] = None
+    associationType: Optional[AssociationTypeModel] = None
+    plmnIndication: Optional[bool] = Field(
+        None,
+        description='If "monitoringType" is "ROAMING_STATUS", this parameter may be included to indicate the notification of UE\'s Serving PLMN ID. Value "true" indicates enabling of notification; "false" indicates disabling of notification. Default value is "false" if omitted.\n',
+    )
+    locationArea: Optional[LocationArea] = None
+    locationArea5G: Optional[LocationArea5G] = None
+    dddTraDescriptors: Optional[List[DddTrafficDescriptor]] = Field(None, min_items=1)
+    dddStati: Optional[List[DlDataDeliveryStatus]] = Field(None, min_items=1)
+    apiNames: Optional[List[str]] = Field(None, min_items=1)
+    monitoringEventReport: Optional[MonitoringEventReport] = None
+    snssai: Optional[Snssai] = None
+    tgtNsThreshold: Optional[SACInfo] = None
+    nsRepFormat: Optional[SACRepFormat] = None
+    afServiceId: Optional[str] = None
+    immediateRep: Optional[bool] = Field(
+        None,
+        description='Indicates whether an immediate reporting is requested or not. "true" indicate an immediate reporting is requested. "false" indicate an immediate reporting is not requested. Default value "false" if omitted.\n',
+    )
+    uavPolicy: Optional[UavPolicy] = None
+    sesEstInd: Optional[bool] = Field(
+        None,
+        description='Set to true by the SCS/AS so that only UAV\'s with "PDU session established for DNN(s) subject to aerial service" are to be listed in the Event report. Set to false or default false if omitted otherwise.\n',
+    )
+    subType: Optional[SubType] = None
+    addnMonTypes: Optional[List[MonitoringType]] = None
+    addnMonEventReports: Optional[List[MonitoringEventReport]] = None
+    ueIpAddr: Optional[IpAddr] = None
+    ueMacAddr: Optional[MacAddr48] = None
+    revocationNotifUri: Optional[AnyUrl] = None
+    reqRangSlRes: Optional[List[RangingSlResult]] = Field(None, min_items=1)
+    relatedUes: Optional[Dict[str, RelatedUeModel]] = Field(
+        None,
+        description="Contains a list of the related UE(s) for the ranging and sidelink positioning and the corresponding information. The key of the map shall be a any unique string set to the value.\n",
+    )

--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -1020,7 +1020,10 @@ class MonitoringEventSubscriptionCreate(ExtraBaseModel):
         "123456789@domain.com",
         description="Globally unique identifier containing a Domain Identifier and a Local Identifier. \<Local Identifier\>@\<Domain Identifier\>",
     )
-    # msisdn: Optional[str] = Field("918369110173", description="Mobile Subscriber ISDN number that consists of Country Code, National Destination Code and Subscriber Number.")
+    msisdn: Optional[str] = Field(
+        "918369110173",
+        description="Mobile Subscriber ISDN number that consists of Country Code, National Destination Code and Subscriber Number.",
+    )
     # externalGroupId: Optional[str] = Field("Group1@domain.com", description="Identifies a group made up of one or more subscriptions associated to a group of IMSIs, containing a Domain Identifier and a Local Identifier. \<Local Identifier\>@\<Domain Identifier\>")
     # addExtGroupIds: Optional[str] = None
     # Remember, when you actually trying to access the database through CRUD methods you need to typecast the pydantic types to strings, int etc.

--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -1256,16 +1256,34 @@ class ServiceIdentity(ExtraBaseModel):
 
 class Fqdn(ExtraBaseModel):
     __root__: constr(
-        regex=r'^([0-9A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?\.)+[A-Za-z]{2,63}\.?$',
+        regex=r"^([0-9A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?\.)+[A-Za-z]{2,63}\.?$",
         min_length=4,
         max_length=253,
-    ) = Field(..., description='Fully Qualified Domain Name')
+    ) = Field(..., description="Fully Qualified Domain Name")
 
 
 class UpLocRepAddrAfRm(ExtraBaseModel):
     ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
     ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
     fqdn: Optional[Fqdn] = None
+
+
+class UpLocRepAddrAfRm2(BaseModel):
+    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
+    ipv6Addrs: List[Ipv6Addr] = Field(..., min_items=1)
+    fqdn: Optional[Fqdn] = None
+
+
+class UpLocRepAddrAfRm3(BaseModel):
+    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
+    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
+    fqdn: Fqdn
+
+
+class UpLocRepAddrAfRm(BaseModel):
+    __root__: Optional[
+        Union[UpLocRepAddrAfRm1, UpLocRepAddrAfRm2, UpLocRepAddrAfRm3]
+    ] = Field(None, description="Represents the user plane addressing information.")
 
 
 class CodeWord(ExtraBaseModel):
@@ -1388,6 +1406,7 @@ class AgeOfLocationEstimate(ExtraBaseModel):
 class TimeWindowModel(ExtraBaseModel):
     startTime: DateTime
     stopTime: DateTime
+
 
 class MonitoringEventSubscription(ExtraBaseModel):
     self: Optional[AnyUrl] = None

--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
+from ipaddress import IPv4Address, IPv6Address
+
 from pydantic import AnyHttpUrl, AnyUrl, Field, IPvAnyAddress, confloat, conint, constr
 
 from .utils import ExtraBaseModel
@@ -55,23 +57,6 @@ class Dnn(ExtraBaseModel):
     )
 
 
-class Ipv4Addr(ExtraBaseModel):
-    __root__: constr(
-        regex=r"^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$"
-    ) = Field(
-        ...,
-        description="String identifying a IPv4 address formatted in the 'dotted decimal' notation as defined in RFC 1166.",
-        example="198.51.100.1",
-    )
-
-
-class Ipv6Addr(ExtraBaseModel):
-    __root__: str = Field(
-        ...,
-        description="String identifying an IPv6 address formatted according to clause 4 of RFC5952. The mixed IPv4 IPv6 notation according to clause 5 of RFC5952 shall not be used.",
-    )
-
-
 class Ipv6Prefix(ExtraBaseModel):
     __root__: str = Field(
         ...,
@@ -83,20 +68,6 @@ class MacAddr48(ExtraBaseModel):
     __root__: constr(regex=r"^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$") = Field(
         ...,
         description="String identifying a MAC address formatted in the hexadecimal notation according to clause 1.1 and clause 2.1 of RFC 7042.",
-    )
-
-
-class Ipv4AddrModel(ExtraBaseModel):
-    __root__: str = Field(
-        ...,
-        description='string identifying a Ipv4 address formatted in the "dotted decimal" notation as defined in IETF RFC 1166.',
-    )
-
-
-class Ipv6AddrModel(ExtraBaseModel):
-    __root__: str = Field(
-        ...,
-        description="string identifying a Ipv6 address formatted according to clause 4 in IETF RFC 5952. The mixed Ipv4 Ipv6 notation according to clause 5 of IETF RFC 5952 shall not be used.",
     )
 
 
@@ -523,8 +494,8 @@ class N3gaLocation(ExtraBaseModel):
         None,
         description='This IE shall contain the N3IWF identifier received over NGAP and shall be encoded as a  string of hexadecimal characters. Each character in the string shall take a value of "0"  to "9", "a" to "f" or "A" to "F" and shall represent 4 bits. The most significant  character representing the 4 most significant bits of the N3IWF ID shall appear first in  the string, and the character representing the 4 least significant bit of the N3IWF ID  shall appear last in the string. \n',
     )
-    ueIpv4Addr: Optional[Ipv4Addr] = None
-    ueIpv6Addr: Optional[Ipv6Addr] = None
+    ueIpv4Addr: Optional[IPv4Address] = None
+    ueIpv6Addr: Optional[IPv6Address] = None
     portNumber: Optional[Uinteger] = None
     protocol: Optional[TransportProtocol] = None
     tnapId: Optional[TnapId] = None
@@ -864,8 +835,8 @@ class AssociationTypeModel(str, Enum):
 class PduSessionInformation(ExtraBaseModel):
     snssai: Snssai
     dnn: Dnn
-    ueIpv4: Optional[Ipv4Addr] = None
-    ueIpv6: Optional[Ipv6Prefix] = None
+    ueIpv4: Optional[IPv4Address] = None
+    ueIpv6: Optional[IPv6Address] = None
     ipDomain: Optional[str] = None
     ueMac: Optional[MacAddr48] = None
 
@@ -961,8 +932,8 @@ class PdnConnectionInformation(ExtraBaseModel):
     )
     pdnType: PdnType
     interfaceInd: Optional[InterfaceIndication] = None
-    ipv4Addr: Optional[Ipv4AddrModel] = None
-    ipv6Addrs: Optional[List[Ipv6AddrModel]] = Field(None, min_items=1)
+    ipv4Addr: Optional[IPv4Address] = None
+    ipv6Addrs: Optional[List[IPv6Address]] = Field(None, min_items=1)
     macAddrs: Optional[List[MacAddr48]] = Field(None, min_items=1)
 
 
@@ -973,8 +944,8 @@ class DlDataDeliveryStatus(str, Enum):
 
 
 class DddTrafficDescriptor(ExtraBaseModel):
-    ipv4Addr: Optional[Ipv4Addr] = None
-    ipv6Addr: Optional[Ipv6Addr] = None
+    ipv4Addr: Optional[IPv4Address] = None
+    ipv6Addr: Optional[IPv6Address] = None
     portNumber: Optional[Uinteger] = None
     macAddr: Optional[MacAddr48] = None
 
@@ -1100,7 +1071,7 @@ class MonitoringEventSubscription(MonitoringEventSubscriptionCreate):
         "https://myresource.com",
         description="String identifying a referenced resource. This is also returned as a location header in 201 Created Response",
     )
-    ipv4Addr: Optional[IPvAnyAddress] = Field(
+    ipv4Addr: Optional[IPv4Address] = Field(
         None, description="String identifying an Ipv4 address"
     )
 
@@ -1263,8 +1234,8 @@ class Fqdn(ExtraBaseModel):
 
 
 class UpLocRepAddrAfRm(ExtraBaseModel):
-    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
-    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
+    ipv4Addrs: Optional[List[IPv4Address]] = Field(None, min_items=1)
+    ipv6Addrs: Optional[List[IPv6Address]] = Field(None, min_items=1)
     fqdn: Optional[Fqdn] = None
 
 
@@ -1308,8 +1279,8 @@ class RangingSlResult(str, Enum):
 
 
 class IpAddr(ExtraBaseModel):
-    ipv4Addr: Optional[Ipv4Addr] = None
-    ipv6Addr: Optional[Ipv6Addr] = None
+    ipv4Addr: Optional[IPv4Address] = None
+    ipv6Addr: Optional[IPv6Address] = None
     ipv6Prefix: Optional[Ipv6Prefix] = None
 
 
@@ -1423,8 +1394,8 @@ class MonitoringEventSubscription(ExtraBaseModel):
     )
     externalGroupId: Optional[ExternalGroupId] = None
     addExtGroupId: Optional[List[ExternalGroupId]] = Field(None, min_items=2)
-    ipv4Addr: Optional[Ipv4AddrModel] = None
-    ipv6Addr: Optional[Ipv6AddrModel] = None
+    ipv4Addr: Optional[IPv4Address] = None
+    ipv6Addr: Optional[IPv6Address] = None
     dnn: Optional[Dnn] = None
     notificationDestination: AnyUrl
     requestTestNotification: Optional[bool] = Field(

--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -1254,28 +1254,18 @@ class ServiceIdentity(ExtraBaseModel):
     __root__: str = Field(..., description="Contains the service identity")
 
 
-class UpLocRepAddrAfRm1(BaseModel):
-    ipv4Addrs: List[Ipv4Addr] = Field(..., min_items=1)
-    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
-    fqdn: Optional[Fqdn] = None
+class Fqdn(ExtraBaseModel):
+    __root__: constr(
+        regex=r'^([0-9A-Za-z]([-0-9A-Za-z]{0,61}[0-9A-Za-z])?\.)+[A-Za-z]{2,63}\.?$',
+        min_length=4,
+        max_length=253,
+    ) = Field(..., description='Fully Qualified Domain Name')
 
 
-class UpLocRepAddrAfRm2(BaseModel):
-    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
-    ipv6Addrs: List[Ipv6Addr] = Field(..., min_items=1)
-    fqdn: Optional[Fqdn] = None
-
-
-class UpLocRepAddrAfRm3(BaseModel):
+class UpLocRepAddrAfRm(ExtraBaseModel):
     ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
     ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
-    fqdn: Fqdn
-
-
-class UpLocRepAddrAfRm(BaseModel):
-    __root__: Optional[
-        Union[UpLocRepAddrAfRm1, UpLocRepAddrAfRm2, UpLocRepAddrAfRm3]
-    ] = Field(None, description="Represents the user plane addressing information.")
+    fqdn: Optional[Fqdn] = None
 
 
 class CodeWord(ExtraBaseModel):

--- a/backend/app/app/schemas/monitoringevent.py
+++ b/backend/app/app/schemas/monitoringevent.py
@@ -1268,24 +1268,6 @@ class UpLocRepAddrAfRm(ExtraBaseModel):
     fqdn: Optional[Fqdn] = None
 
 
-class UpLocRepAddrAfRm2(BaseModel):
-    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
-    ipv6Addrs: List[Ipv6Addr] = Field(..., min_items=1)
-    fqdn: Optional[Fqdn] = None
-
-
-class UpLocRepAddrAfRm3(BaseModel):
-    ipv4Addrs: Optional[List[Ipv4Addr]] = Field(None, min_items=1)
-    ipv6Addrs: Optional[List[Ipv6Addr]] = Field(None, min_items=1)
-    fqdn: Fqdn
-
-
-class UpLocRepAddrAfRm(BaseModel):
-    __root__: Optional[
-        Union[UpLocRepAddrAfRm1, UpLocRepAddrAfRm2, UpLocRepAddrAfRm3]
-    ] = Field(None, description="Represents the user plane addressing information.")
-
-
 class CodeWord(ExtraBaseModel):
     __root__: str = Field(..., description="Contains the codeword")
 

--- a/backend/app/app/tools/check_subscription.py
+++ b/backend/app/app/tools/check_subscription.py
@@ -1,61 +1,21 @@
 import logging
+from math import exp
 import time
-from typing import Optional
+from datetime import date, datetime
+from typing import Optional, Union
 from app.crud import crud_mongo
 
 
-def check_expiration_time(expire_time):
+def check_expiration_time(expire_time: Union[datetime, str]) -> bool:
     if not expire_time:
         return True
 
-    year = int(expire_time[0:4])
-    month = int(expire_time[5:7])
-    day = int(expire_time[8:10])
-    hour = int(expire_time[11:13])
-    minute = int(expire_time[14:16])
-    sec = int(expire_time[17:19])
+    if isinstance(expire_time, str):
+        expire_time = datetime.fromisoformat(expire_time)
 
-    time_now = time.localtime()
-    # print(time.asctime(time_now))
+    now = datetime.now(expire_time.tzinfo) if expire_time.tzinfo else datetime.now()
 
-    if year > time_now[0]:
-        # print(year, time_now[0])
-        return True
-    elif year == time_now[0]:
-        if month > time_now[1]:
-            # print(month, time_now[1])
-            return True
-        elif month == time_now[1]:
-            if day > time_now[2]:
-                # print(day, time_now[2])
-                return True
-            elif day == time_now[2]:
-                # print("Day == day now", day, time_now[2])
-                if hour > time_now[3]:
-                    # print(hour, time_now[3])
-                    return True
-                elif hour == time_now[3]:
-                    # print("Time == time now", hour, time_now[3])
-                    if minute > time_now[4]:
-                        print(minute, time_now[4])
-                        return True
-                    elif minute == time_now[4]:
-                        # print("Minute == minute now", minute, time_now[4])
-                        if sec >= time_now[5]:
-                            # print(sec, time_now[5])
-                            return True
-                        else:
-                            return False
-                    else:
-                        return False
-                else:
-                    return False
-            else:
-                return False
-        else:
-            return False
-    else:
-        return False
+    return now < expire_time
 
 
 def check_numberOfReports(maximum_number_of_reports: Optional[int]) -> bool:

--- a/backend/app/app/tools/check_subscription.py
+++ b/backend/app/app/tools/check_subscription.py
@@ -2,7 +2,11 @@ import logging
 import time
 from app.crud import crud_mongo
 
+
 def check_expiration_time(expire_time):
+    if not expire_time:
+        return True
+
     year = int(expire_time[0:4])
     month = int(expire_time[5:7])
     day = int(expire_time[8:10])
@@ -12,31 +16,31 @@ def check_expiration_time(expire_time):
 
     time_now = time.localtime()
     # print(time.asctime(time_now))
-    
-    if year>time_now[0]: 
+
+    if year > time_now[0]:
         # print(year, time_now[0])
         return True
     elif year == time_now[0]:
         if month > time_now[1]:
             # print(month, time_now[1])
             return True
-        elif(month == time_now[1]):
-            if(day>time_now[2]):
+        elif month == time_now[1]:
+            if day > time_now[2]:
                 # print(day, time_now[2])
                 return True
-            elif(day==time_now[2]):
+            elif day == time_now[2]:
                 # print("Day == day now", day, time_now[2])
-                if(hour>time_now[3]):
+                if hour > time_now[3]:
                     # print(hour, time_now[3])
                     return True
-                elif(hour==time_now[3]):
+                elif hour == time_now[3]:
                     # print("Time == time now", hour, time_now[3])
-                    if(minute>time_now[4]):
+                    if minute > time_now[4]:
                         print(minute, time_now[4])
                         return True
-                    elif(minute==time_now[4]):
+                    elif minute == time_now[4]:
                         # print("Minute == minute now", minute, time_now[4])
-                        if(sec>=time_now[5]):
+                        if sec >= time_now[5]:
                             # print(sec, time_now[5])
                             return True
                         else:
@@ -52,9 +56,13 @@ def check_expiration_time(expire_time):
     else:
         return False
 
+
 def check_numberOfReports(maximum_number_of_reports: int) -> bool:
+    if not maximum_number_of_reports:
+        return True
+
     if maximum_number_of_reports >= 1:
         return True
-    else:
-        logging.warning("Subscription has expired (maximum number of reports")
-        return False
+
+    logging.warning("Subscription has expired (maximum number of reports")
+    return False

--- a/backend/app/app/tools/check_subscription.py
+++ b/backend/app/app/tools/check_subscription.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Optional
 from app.crud import crud_mongo
 
 
@@ -57,12 +58,12 @@ def check_expiration_time(expire_time):
         return False
 
 
-def check_numberOfReports(maximum_number_of_reports: int) -> bool:
-    if not maximum_number_of_reports:
+def check_numberOfReports(maximum_number_of_reports: Optional[int]) -> bool:
+    if maximum_number_of_reports is None:
         return True
 
-    if maximum_number_of_reports >= 1:
-        return True
+    if maximum_number_of_reports < 0:
+        logging.warning("Subscription has expired (maximum number of reports)")
+        return False
 
-    logging.warning("Subscription has expired (maximum number of reports")
-    return False
+    return True

--- a/backend/app/app/tools/distance.py
+++ b/backend/app/app/tools/distance.py
@@ -1,35 +1,42 @@
 import math
+from typing import List
+from app.models.UE import UE
+from app.models.Cell import Cell
 
-def distance(lat1, lon1, lat2, lon2): #Haversine formula: determines the great-circle distance between two points on a sphere given their longitudes and latitudes.
+
+def distance(
+    lat1, lon1, lat2, lon2
+):  # Haversine formula: determines the great-circle distance between two points on a sphere given their longitudes and latitudes.
     R = 6371e3
     φ1 = lat1 * math.pi / 180  # φ, λ in radians
     φ2 = lat2 * math.pi / 180
     Δλ = (lon2 - lon1) * math.pi / 180
     Δφ = (lat2 - lat1) * math.pi / 180
 
-    a = math.sin(Δφ / 2) * math.sin(Δφ / 2) + math.cos(φ1) * math.cos(φ2) * math.sin(Δλ / 2) * math.sin(Δλ / 2)
+    a = math.sin(Δφ / 2) * math.sin(Δφ / 2) + math.cos(φ1) * math.cos(φ2) * math.sin(
+        Δλ / 2
+    ) * math.sin(Δλ / 2)
     c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
     d = R * c  # in metres
 
     return d
 
-def check_distance(UE_lat, UE_long, cells):
-    
-    # logging.info(f"Current cell {current_cell}") 
-    current_cell = None      
+
+def check_distance(lat, lon, cells: List[Cell]):
+
+    # logging.info(f"Current cell {current_cell}")
+    current_cell = None
     current_cell_dist = float("inf")
     distances = {}
     for cell in cells:
-        dist = distance(UE_lat, UE_long, cell.get("latitude"), cell.get("longitude"))
-        distances[f"{cell.get('id')}"]= dist
-        #print(f"Distance = {dist} meters from Cell {cell.get('description')}") 
-        if (dist <= cell.get("radius")):
-            if (dist < current_cell_dist):
+        dist = distance(lat, lon, cell.latitude, cell.longitude)
+        distances[f"{cell.id}"] = dist
+        # print(f"Distance = {dist} meters from Cell {cell.get('description')}")
+        if dist <= cell.radius:
+            if dist < current_cell_dist:
                 current_cell_dist = dist
                 current_cell = cell
-    
-    return current_cell, distances
-        
 
-    
+    return current_cell, distances
+

--- a/backend/app/app/tools/monitoring_callbacks.py
+++ b/backend/app/app/tools/monitoring_callbacks.py
@@ -1,29 +1,40 @@
-import requests, json
+import json
 
-from app.schemas.monitoringevent import MonitoringEventReport, MonitoringNotification, MonitoringType, LocationInfo, Point, SupportedGADShapes, GeographicalCoordinates
+import requests
+
+from app.schemas.monitoringevent import (
+    GeographicalCoordinates,
+    LocationInfo,
+    MonitoringEventReport,
+    MonitoringNotification,
+    MonitoringType,
+    Point,
+    SupportedGADShapes,
+)
+
 
 def location_callback(ue, callbackurl, subscription):
     url = callbackurl
 
     notification = MonitoringNotification(
-        subscription = subscription,
-        monitoringEventReports = [
+        subscription=subscription,
+        monitoringEventReports=[
             MonitoringEventReport(
-                externalId = ue.get("external_identifier"),
-                monitoringType = MonitoringType.locationReporting,
-                locationInfo = LocationInfo(
-                    cellId = ue.get("cell_id_hex"),
-                    enodeBId = ue.get("gnb_id_hex"),
-                    geographicArea = Point(
-                        shape = SupportedGADShapes.POINT,
-                        point = GeographicalCoordinates(
-                            lat = ue.get("latitude"),
-                            lon = ue.get("longitude"),
-                        )
-                    )
-                )
+                externalId=ue.get("external_identifier"),
+                monitoringType=MonitoringType.LOCATION_REPORTING,
+                locationInfo=LocationInfo(
+                    cellId=ue.get("cell_id_hex"),
+                    enodeBId=ue.get("gnb_id_hex"),
+                    geographicArea=Point(
+                        shape=SupportedGADShapes.POINT,
+                        point=GeographicalCoordinates(
+                            lat=ue.get("latitude"),
+                            lon=ue.get("longitude"),
+                        ),
+                    ),
+                ),
             )
-        ]
+        ],
     )
     headers = {"accept": "application/json", "Content-Type": "application/json"}
 
@@ -32,53 +43,61 @@ def location_callback(ue, callbackurl, subscription):
     # (i.e., connect timeout means that the server is unreachable and read that the server is reachable but the client does not receive a response within 27 seconds)
 
     response = requests.request(
-        "POST", url, headers=headers, data=notification.json(exclude_unset=True), timeout=(3.05, 27)
+        "POST",
+        url,
+        headers=headers,
+        data=notification.json(exclude_unset=True),
+        timeout=(3.05, 27),
     )
 
     return response
 
+
 def loss_of_connectivity_callback(ue, callbackurl, subscription):
     url = callbackurl
 
-    payload = json.dumps({
-    "externalId" : ue.get("external_identifier"),
-    "ipv4Addr" : ue.get("ip_address_v4"),
-    "subscription" : subscription,
-    "monitoringType": "LOSS_OF_CONNECTIVITY",
-    "lossOfConnectReason": 7
-    })
-    headers = {
-    'accept': 'application/json',
-    'Content-Type': 'application/json'
-    }
+    payload = json.dumps(
+        {
+            "externalId": ue.get("external_identifier"),
+            "ipv4Addr": ue.get("ip_address_v4"),
+            "subscription": subscription,
+            "monitoringType": "LOSS_OF_CONNECTIVITY",
+            "lossOfConnectReason": 7,
+        }
+    )
+    headers = {"accept": "application/json", "Content-Type": "application/json"}
 
-    #Timeout values according to https://docs.python-requests.org/en/master/user/advanced/#timeouts 
-    #First value of the tuple "3.05" corresponds to connect and second "27" to read timeouts 
-    #(i.e., connect timeout means that the server is unreachable and read that the server is reachable but the client does not receive a response within 27 seconds)
-    
-    response = requests.request("POST", url, headers=headers, data=payload, timeout=(3.05, 27))
-    
+    # Timeout values according to https://docs.python-requests.org/en/master/user/advanced/#timeouts
+    # First value of the tuple "3.05" corresponds to connect and second "27" to read timeouts
+    # (i.e., connect timeout means that the server is unreachable and read that the server is reachable but the client does not receive a response within 27 seconds)
+
+    response = requests.request(
+        "POST", url, headers=headers, data=payload, timeout=(3.05, 27)
+    )
+
     return response
+
 
 def ue_reachability_callback(ue, callbackurl, subscription, reachabilityType):
     url = callbackurl
 
-    payload = json.dumps({
-    "externalId" : ue.get("external_identifier"),
-    "ipv4Addr" : ue.get("ip_address_v4"),
-    "subscription" : subscription,
-    "monitoringType": "UE_REACHABILITY",
-    "reachabilityType": reachabilityType
-    })
-    headers = {
-    'accept': 'application/json',
-    'Content-Type': 'application/json'
-    }
+    payload = json.dumps(
+        {
+            "externalId": ue.get("external_identifier"),
+            "ipv4Addr": ue.get("ip_address_v4"),
+            "subscription": subscription,
+            "monitoringType": "UE_REACHABILITY",
+            "reachabilityType": reachabilityType,
+        }
+    )
+    headers = {"accept": "application/json", "Content-Type": "application/json"}
 
-    #Timeout values according to https://docs.python-requests.org/en/master/user/advanced/#timeouts 
-    #First value of the tuple "3.05" corresponds to connect and second "27" to read timeouts 
-    #(i.e., connect timeout means that the server is unreachable and read that the server is reachable but the client does not receive a response within 27 seconds)
-    
-    response = requests.request("POST", url, headers=headers, data=payload, timeout=(3.05, 27))
-    
+    # Timeout values according to https://docs.python-requests.org/en/master/user/advanced/#timeouts
+    # First value of the tuple "3.05" corresponds to connect and second "27" to read timeouts
+    # (i.e., connect timeout means that the server is unreachable and read that the server is reachable but the client does not receive a response within 27 seconds)
+
+    response = requests.request(
+        "POST", url, headers=headers, data=payload, timeout=(3.05, 27)
+    )
+
     return response


### PR DESCRIPTION
This PR aims to fix some existing issues in how NEF Emulator handles location, as well as extending functionality.
The changes made consist of changing the NEF Emulator to receive location updates through a new API (outside the /nef path, as this won't be a standards based API). This API can be called by external providers like a location simulator or a digital twin. The API should receive the lat and lon of the device and a suitable device identifier (external identifier or supi).

The way the notifications are sent as also been refactored, and is now using FastAPI Background Tasks, instead of a Thread.
Some other issues have been fixed, such as only supporting one subscription per device, or notifications not being sent every time.

The Monitoring Event part as also been updated to Release 18.