### PR TITLE
Implement support for the `ROAMING_STATUS` monitoring type

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/UE.py
+++ b/backend/app/app/api/api_v1/endpoints/UE.py
@@ -1,18 +1,28 @@
-from typing import Any, List
+import asyncio
+from typing import Any, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.encoders import jsonable_encoder
+
 # from fastapi.responses import JSONResponse
 # from sqlalchemy import null
 from sqlalchemy.orm import Session
-from app import crud, models, schemas
 from app.api import deps
+from app import crud, models, schemas
+from app.db.session import client
 from app.api.api_v1.endpoints.ue_movement import retrieve_ue_state
 from app.api.api_v1.endpoints.paths import get_random_point
+from app.schemas.monitoringevent import MonitoringType
+from app.tools.monitoring_callbacks import (
+    get_subscription_mon_types,
+    send_roaming_status_callback,
+)
+
 # from app.api.api_v1.endpoints.ue_movement import retrieve_ue, retrieve_ue_distances, retrieve_ue_path_losses, retrieve_ue_rsrps, retrieve_ue_handovers
 from .utils import ReportLogging
 
 router = APIRouter()
 router.route_class = ReportLogging
+
 
 @router.get("", response_model=List[schemas.UEhex])
 def read_UEs(
@@ -34,14 +44,13 @@ def read_UEs(
 
     for json_UE in json_UEs:
         for UE in UEs:
-            if UE.Cell_id == json_UE.get('Cell_id'):
+            if UE.Cell_id == json_UE.get("Cell_id"):
                 if UE.Cell_id != None:
                     json_UE.update({"cell_id_hex": UE.Cell.cell_id})
-                    json_UE.update({"gNB_id" : UE.Cell.gNB_id})
+                    json_UE.update({"gNB_id": UE.Cell.gNB_id})
                 else:
                     json_UE.update({"cell_id_hex": None})
-                    json_UE.update({"gNB_id" : None})
-
+                    json_UE.update({"gNB_id": None})
 
     return json_UEs
 
@@ -56,36 +65,51 @@ def create_UE(
     """
     Create new UE.
     """
-    #Validate Unique ids
+    # Validate Unique ids
     if crud.ue.get_supi(db=db, supi=item_in.supi):
         raise HTTPException(
-            status_code=409, detail=f"UE with supi {item_in.supi} already exists")
-    elif crud.ue.get_ipv4(db=db, ipv4=str(item_in.ip_address_v4), owner_id=current_user.id):
+            status_code=409, detail=f"UE with supi {item_in.supi} already exists"
+        )
+    elif crud.ue.get_ipv4(
+        db=db, ipv4=str(item_in.ip_address_v4), owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"UE with ipv4 {str(item_in.ip_address_v4)} already exists")
-    elif crud.ue.get_ipv6(db=db, ipv6=str(item_in.ip_address_v6.exploded), owner_id=current_user.id):
+            status_code=409,
+            detail=f"UE with ipv4 {str(item_in.ip_address_v4)} already exists",
+        )
+    elif crud.ue.get_ipv6(
+        db=db, ipv6=str(item_in.ip_address_v6.exploded), owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"UE with ipv6 {str(item_in.ip_address_v6)} already exists")
+            status_code=409,
+            detail=f"UE with ipv6 {str(item_in.ip_address_v6)} already exists",
+        )
     elif crud.ue.get_mac(db=db, mac=str(item_in.mac_address), owner_id=current_user.id):
         raise HTTPException(
-            status_code=409, detail=f"UE with mac {str(item_in.mac_address)} already exists")
-    elif crud.ue.get_externalId(db=db, externalId=item_in.external_identifier, owner_id=current_user.id):
+            status_code=409,
+            detail=f"UE with mac {str(item_in.mac_address)} already exists",
+        )
+    elif crud.ue.get_externalId(
+        db=db, externalId=item_in.external_identifier, owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"UE with external id {str(item_in.mac_address)} already exists")
+            status_code=409,
+            detail=f"UE with external id {str(item_in.mac_address)} already exists",
+        )
 
     json_data = jsonable_encoder(item_in)
-    json_data['ip_address_v4'] = str(item_in.ip_address_v4)
-    json_data['ip_address_v6'] = str(item_in.ip_address_v6.exploded)
-    json_data['Cell_id'] = None
+    json_data["ip_address_v4"] = str(item_in.ip_address_v4)
+    json_data["ip_address_v6"] = str(item_in.ip_address_v6.exploded)
+    json_data["Cell_id"] = None
 
     UE = crud.ue.create_with_owner(db=db, obj_in=json_data, owner_id=current_user.id)
-    json_data.update({"path_id" : 0})
+    json_data.update({"path_id": 0})
 
     return json_data
 
 
 @router.put("/{supi}", response_model=schemas.UE)
-def update_UE(
+async def update_UE(
     *,
     db: Session = Depends(deps.get_db),
     supi: str = Path(..., description="The SUPI of the UE you want to update"),
@@ -104,35 +128,76 @@ def update_UE(
     ipv4_str = str(item_in.ip_address_v4)
     ipv6_str = item_in.ip_address_v6.exploded
 
-    if (UE.ip_address_v4 != ipv4_str) and crud.ue.get_ipv4(db=db, ipv4=ipv4_str, owner_id=current_user.id):
+    if (UE.ip_address_v4 != ipv4_str) and crud.ue.get_ipv4(
+        db=db, ipv4=ipv4_str, owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"This ipv4 {ipv4_str} already exists")
-    elif (UE.ip_address_v6 != ipv6_str) and crud.ue.get_ipv6(db=db, ipv6=ipv6_str, owner_id=current_user.id):
+            status_code=409, detail=f"This ipv4 {ipv4_str} already exists"
+        )
+    elif (UE.ip_address_v6 != ipv6_str) and crud.ue.get_ipv6(
+        db=db, ipv6=ipv6_str, owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"This ipv6 {ipv6_str} already exists")
-    elif (UE.mac_address != item_in.mac_address) and crud.ue.get_mac(db=db, mac=str(item_in.mac_address), owner_id=current_user.id):
+            status_code=409, detail=f"This ipv6 {ipv6_str} already exists"
+        )
+    elif (UE.mac_address != item_in.mac_address) and crud.ue.get_mac(
+        db=db, mac=str(item_in.mac_address), owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"This mac {item_in.mac_address} already exists")
-    elif (UE.external_identifier != item_in.external_identifier) and crud.ue.get_externalId(db=db, externalId=item_in.external_identifier, owner_id=current_user.id):
+            status_code=409, detail=f"This mac {item_in.mac_address} already exists"
+        )
+    elif (
+        UE.external_identifier != item_in.external_identifier
+    ) and crud.ue.get_externalId(
+        db=db, externalId=item_in.external_identifier, owner_id=current_user.id
+    ):
         raise HTTPException(
-            status_code=409, detail=f"This external id {item_in.mac_address} already exists")
+            status_code=409,
+            detail=f"This external id {item_in.mac_address} already exists",
+        )
+
+    _update_roaming_status(UE, item_in.visiting_plmnid)
 
     json_data = jsonable_encoder(item_in)
-    json_data['ip_address_v4'] = str(item_in.ip_address_v4)
-    json_data['ip_address_v6'] = str(item_in.ip_address_v6.exploded)
+    json_data["ip_address_v4"] = str(item_in.ip_address_v4)
+    json_data["ip_address_v6"] = str(item_in.ip_address_v6.exploded)
 
     UE = crud.ue.update(db=db, db_obj=UE, obj_in=json_data)
-    json_data.update({"supi": supi, "path_id" : UE.path_id})
+    json_data.update({"supi": supi, "path_id": UE.path_id})
 
     return json_data
+
+
+def _update_roaming_status(ue: models.UE, new_vplmnid: Optional[str]):
+    if ue.visiting_plmnid == new_vplmnid:
+        return
+
+    db_mongo = client.fastapi
+
+    subscriptions = db_mongo["MonitoringEvent"].find(
+        {"supi": str(ue.supi)}, {"subscription": True}
+    )
+
+    for doc in subscriptions:
+        doc_id = doc.get("_id")
+        sub = doc["subscription"]
+
+        for monType in get_subscription_mon_types(sub):
+            if monType == MonitoringType.ROAMING_STATUS:
+                if (
+                    not sub.get("plmnIndication")
+                    and ue.visiting_plmnid is None == new_vplmnid is None
+                ):
+                    continue
+
+                asyncio.create_task(send_roaming_status_callback(sub, ue, doc_id))
 
 
 @router.get("/{supi}", response_model=schemas.UE)
 def read_UE(
     *,
     db: Session = Depends(deps.get_db),
-    supi: str = Path(...,
-                     description="The SUPI of the UE you want to retrieve"),
+    supi: str = Path(..., description="The SUPI of the UE you want to retrieve"),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
@@ -146,13 +211,11 @@ def read_UE(
 
     json_UE = jsonable_encoder(UE)
     if UE.Cell_id != None:
-        json_UE.update({"gNB_id" : UE.Cell.gNB_id})
+        json_UE.update({"gNB_id": UE.Cell.gNB_id})
     else:
-        json_UE.update({"gNB_id" : None})
+        json_UE.update({"gNB_id": None})
 
     return json_UE
-
-
 
 
 @router.delete("/{supi}", response_model=schemas.UE)
@@ -173,25 +236,30 @@ def delete_UE(
 
     if retrieve_ue_state(supi, current_user.id):
         raise HTTPException(
-            status_code=400, detail=f"UE with SUPI {supi} is currently moving. You are not allowed to remove a UE while it's moving")
+            status_code=400,
+            detail=f"UE with SUPI {supi} is currently moving. You are not allowed to remove a UE while it's moving",
+        )
     else:
         json_UE = jsonable_encoder(UE)
         if UE.Cell_id != None:
-            json_UE.update({"gNB_id" : UE.Cell.gNB_id})
+            json_UE.update({"gNB_id": UE.Cell.gNB_id})
         else:
-            json_UE.update({"gNB_id" : None})
+            json_UE.update({"gNB_id": None})
 
         crud.ue.remove_supi(db=db, supi=supi)
         return json_UE
 
+
 ### Get list of UEs of specific gNB
+
 
 @router.get("/by_gNB/{gNB_id}", response_model=List[schemas.UE])
 def read_gNB_id(
     *,
     db: Session = Depends(deps.get_db),
-    gNB_id: str = Path(..., description="The gNB id of the gNB in hexadecimal format",
-                       example='AAAAA1'),
+    gNB_id: str = Path(
+        ..., description="The gNB id of the gNB in hexadecimal format", example="AAAAA1"
+    ),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
@@ -199,8 +267,7 @@ def read_gNB_id(
     """
     gNB = crud.gnb.get_gNB_id(db=db, id=gNB_id)
     if not gNB:
-        raise HTTPException(
-            status_code=404, detail=f"gNB with id {gNB_id} not found")
+        raise HTTPException(status_code=404, detail=f"gNB with id {gNB_id} not found")
     if not crud.user.is_superuser(current_user) and (gNB.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
@@ -212,16 +279,17 @@ def read_gNB_id(
         json_UEs = jsonable_encoder(UEs)
         for json_UE in json_UEs:
             for UE in UEs:
-                if UE.Cell_id == json_UE.get('Cell_id'):
+                if UE.Cell_id == json_UE.get("Cell_id"):
                     if UE.Cell_id != None:
-                        json_UE.update({"gNB_id" : UE.Cell.gNB_id})
+                        json_UE.update({"gNB_id": UE.Cell.gNB_id})
                     else:
-                        json_UE.update({"gNB_id" : None})
+                        json_UE.update({"gNB_id": None})
         ue_list.extend(json_UEs)
 
     if not ue_list:
         raise HTTPException(
-            status_code=404, detail="There are no UEs associated with this gNB")
+            status_code=404, detail="There are no UEs associated with this gNB"
+        )
     if not crud.user.is_superuser(current_user):
         raise HTTPException(status_code=400, detail="Not enough permissions")
     return ue_list
@@ -229,12 +297,16 @@ def read_gNB_id(
 
 ### Get list of UEs of Specific Cells
 
+
 @router.get("/by_Cell/{cell_id}", response_model=List[schemas.UE])
 def read_UE_Cell(
     *,
     db: Session = Depends(deps.get_db),
-    cell_id: str = Path(..., description="The cell id of the cell in hexadecimal format",
-                        example='AAAAA1001'),
+    cell_id: str = Path(
+        ...,
+        description="The cell id of the cell in hexadecimal format",
+        example="AAAAA1001",
+    ),
     current_user: models.User = Depends(deps.get_current_active_user),
 ) -> Any:
     """
@@ -242,30 +314,31 @@ def read_UE_Cell(
     """
     cell = crud.cell.get_Cell_id(db=db, id=cell_id)
     if not cell:
-        raise HTTPException(
-            status_code=404, detail=f"Cell with id {cell_id} not found")
+        raise HTTPException(status_code=404, detail=f"Cell with id {cell_id} not found")
     if not crud.user.is_superuser(current_user) and (cell.owner_id != current_user.id):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
     UEs = crud.ue.get_by_Cell(db=db, cell_id=cell.id)
     if not UEs:
         raise HTTPException(
-            status_code=404, detail="There are no UEs associated with this cell")
+            status_code=404, detail="There are no UEs associated with this cell"
+        )
     if not crud.user.is_superuser(current_user):
         raise HTTPException(status_code=400, detail="Not enough permissions")
 
     json_UEs = jsonable_encoder(UEs)
     for json_UE in json_UEs:
         for UE in UEs:
-            if UE.Cell_id == json_UE.get('Cell_id'):
+            if UE.Cell_id == json_UE.get("Cell_id"):
                 if UE.Cell_id != None:
-                    json_UE.update({"gNB_id" : UE.Cell.gNB_id})
+                    json_UE.update({"gNB_id": UE.Cell.gNB_id})
                 else:
-                    json_UE.update({"gNB_id" : None})
+                    json_UE.update({"gNB_id": None})
 
     return json_UEs
 
-#Assign paths to UEs
+
+# Assign paths to UEs
 @router.post("/associate/path", response_model=schemas.ue_path)
 def assign_predefined_path(
     *,
@@ -277,7 +350,10 @@ def assign_predefined_path(
     Assign paths to UEs
     """
     if retrieve_ue_state(item_in.supi, current_user.id):
-        raise HTTPException(status_code=400, detail=f"UE with SUPI {item_in.supi} is currently moving. You are not allowed to edit UE's path while it's moving")
+        raise HTTPException(
+            status_code=400,
+            detail=f"UE with SUPI {item_in.supi} is currently moving. You are not allowed to edit UE's path while it's moving",
+        )
 
     UE = crud.ue.get_supi(db=db, supi=item_in.supi)
     if not UE:
@@ -289,18 +365,20 @@ def assign_predefined_path(
         path = crud.path.get(db=db, id=item_in.path)
         if not path:
             raise HTTPException(
-                status_code=409, detail="ERROR: This path_id you specified doesn't exist. Please create a new path with this path_id or use an existing path")
+                status_code=409,
+                detail="ERROR: This path_id you specified doesn't exist. Please create a new path with this path_id or use an existing path",
+            )
     elif item_in.path == 0:
-        crud.ue.update(db=db, db_obj=UE, obj_in={'path_id' : 0})
+        crud.ue.update(db=db, db_obj=UE, obj_in={"path_id": 0})
         return item_in
-    
-    #Assign the coordinates on path change
+
+    # Assign the coordinates on path change
     if UE.path_id != item_in.path:
         json_data = jsonable_encoder(UE)
-        json_data['path_id'] = item_in.path
+        json_data["path_id"] = item_in.path
         random_point = get_random_point(db, item_in.path)
-        json_data['latitude'] = random_point.get('latitude')
-        json_data['longitude'] = random_point.get('longitude')
+        json_data["latitude"] = random_point.get("latitude")
+        json_data["longitude"] = random_point.get("longitude")
         crud.ue.update(db=db, db_obj=UE, obj_in=json_data)
 
     return item_in

--- a/backend/app/app/models/UE.py
+++ b/backend/app/app/models/UE.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-#from sqlalchemy import Boolean, Column, Integer, String
+# from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy import Column, Integer, String, Float, ForeignKey
 from sqlalchemy.orm import relationship
 
@@ -16,7 +16,7 @@ class UE(Base):
     # id for db/primary key
     id = Column(Integer, primary_key=True, index=True)
 
-    #id for UE (representing IMSI)
+    # id for UE (representing IMSI)
     supi = Column(String, index=True)
     name = Column(String, index=True)
     description = Column(String, index=True)
@@ -32,12 +32,12 @@ class UE(Base):
     latitude = Column(Float, index=True)
     longitude = Column(Float, index=True)
     path_id = Column(Integer, index=True)
+    visiting_plmnid = Column(String, nullable=True, default=None)
 
-    #Foreign Keys
+    # Foreign Keys
     owner_id = Column(Integer, ForeignKey("user.id"))
     Cell_id = Column(Integer, ForeignKey("cell.id"))
-    
 
-    #Relationships
+    # Relationships
     owner = relationship("User", back_populates="UEs")
     Cell = relationship("Cell", back_populates="UE")

--- a/backend/app/app/schemas/UE.py
+++ b/backend/app/app/schemas/UE.py
@@ -1,54 +1,102 @@
-from typing import Optional, Annotated
+from typing import Optional
+from typing_extensions import Annotated
 from enum import Enum
 from pydantic import BaseModel, IPvAnyAddress, Field, constr, confloat
 
 from app.schemas.commonData import Msisdn
-from typing_extensions import Annotated
+
 
 class Speed(str, Enum):
     stationary = "STATIONARY"
     low = "LOW"
     high = "HIGH"
 
+
 # Shared properties
 class UEBase(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
-    ip_address_v4: Optional[IPvAnyAddress] = Field(default='10.0.0.0', description="String identifying an Ipv4 address")    
-    ip_address_v6: Optional[IPvAnyAddress] = Field(default="0:0:0:0:0:0:0:0", description="String identifying an Ipv6 address. Default value ::1/128 (loopback)")
-    mac_address: constr(regex=r'^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$') = '22-00-00-00-00-00'
-    msisdn: Annotated[Optional[Msisdn], Field(description="String identifying a phone number (MSISDN)")] = "2020100000000"
-    dnn: Optional[str] = Field(default='province1.mnc01.mcc202.gprs', description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003")
-    mcc: Optional[int] = Field(default=202, description="Mobile Country Code (MCC) part of the Public Land Mobile Network (PLMN), comprising 3 digits, as defined in clause 9.3.3.5 of 3GPP TS 38.413")
-    mnc: Optional[int] = Field(default=1, description="Mobile Network Code (MNC) part of the Public Land Mobile Network (PLMN), comprising 2 or 3 digits, as defined in clause 9.3.3.5 of 3GPP TS 38.413")
-    external_identifier: Optional[str] = Field("123456789@domain.com", description="Globally unique identifier containing a Domain Identifier and a Local Identifier. \<Local Identifier\>@\<Domain Identifier\>")
-    speed: Speed = Field(default="LOW", description="This value describes UE's speed. Possible values are \"STATIONARY\" (e.g, IoT device), \"LOW(e.g, pedestrian)\" and \"HIGH (e.g., vehicle)\"")
+    ip_address_v4: Optional[IPvAnyAddress] = Field(
+        default="10.0.0.0", description="String identifying an Ipv4 address"
+    )
+    ip_address_v6: Optional[IPvAnyAddress] = Field(
+        default="0:0:0:0:0:0:0:0",
+        description="String identifying an Ipv6 address. Default value ::1/128 (loopback)",
+    )
+    mac_address: constr(regex=r"^([0-9a-fA-F]{2})((-[0-9a-fA-F]{2}){5})$") = (
+        "22-00-00-00-00-00"
+    )
+    msisdn: Annotated[
+        Optional[Msisdn],
+        Field(description="String identifying a phone number (MSISDN)"),
+    ] = "2020100000000"
+    dnn: Optional[str] = Field(
+        default="province1.mnc01.mcc202.gprs",
+        description="String identifying the Data Network Name (i.e., Access Point Name in 4G). For more information check clause 9A of 3GPP TS 23.003",
+    )
+    mcc: Optional[int] = Field(
+        default=202,
+        description="Mobile Country Code (MCC) part of the Public Land Mobile Network (PLMN), comprising 3 digits, as defined in clause 9.3.3.5 of 3GPP TS 38.413",
+    )
+    mnc: Optional[int] = Field(
+        default=1,
+        description="Mobile Network Code (MNC) part of the Public Land Mobile Network (PLMN), comprising 2 or 3 digits, as defined in clause 9.3.3.5 of 3GPP TS 38.413",
+    )
+    external_identifier: Optional[str] = Field(
+        "123456789@domain.com",
+        description="Globally unique identifier containing a Domain Identifier and a Local Identifier. \<Local Identifier\>@\<Domain Identifier\>",
+    )
+    visiting_plmnid: Annotated[
+        Optional[str],
+        Field(
+            regex="[0-9]{3}-[0-9]{2,3}",
+            description="The PLMN ID of the visiting network when roaming",
+        ),
+    ] = None
+    speed: Speed = Field(
+        default="LOW",
+        description='This value describes UE\'s speed. Possible values are "STATIONARY" (e.g, IoT device), "LOW(e.g, pedestrian)" and "HIGH (e.g., vehicle)"',
+    )
+
 
 class UECreate(UEBase):
-    supi: constr(regex=r'^[0-9]{15,16}$') = Field(default="202010000000000", description= """String identifying a Supi that shall contain either an IMSI, a network specific identifier, a Global Cable Identifier (GCI) or a Global Line Identifier (GLI) as specified in clause 2.2A of 3GPP TS 23.003. 
-                                                                                             In the current version (v1.1.0) only IMSI is supported""")
+    supi: constr(regex=r"^[0-9]{15,16}$") = Field(
+        default="202010000000000",
+        description="""String identifying a Supi that shall contain either an IMSI, a network specific identifier, a Global Cable Identifier (GCI) or a Global Line Identifier (GLI) as specified in clause 2.2A of 3GPP TS 23.003. 
+                                                                                             In the current version (v1.1.0) only IMSI is supported""",
+    )
+
 
 class UEUpdate(UEBase):
     pass
 
+
 class ue_path(BaseModel):
-    supi: constr(regex=r'^[0-9]{15,16}$') = Field(default="202010000000000", description= """String identifying a Supi that shall contain either an IMSI, a network specific identifier, a Global Cable Identifier (GCI) or a Global Line Identifier (GLI) as specified in clause 2.2A of 3GPP TS 23.003.                                                                                                                                                                             In the current version (v1.1.0) only IMSI is supported""")    
+    supi: constr(regex=r"^[0-9]{15,16}$") = Field(
+        default="202010000000000",
+        description="""String identifying a Supi that shall contain either an IMSI, a network specific identifier, a Global Cable Identifier (GCI) or a Global Line Identifier (GLI) as specified in clause 2.2A of 3GPP TS 23.003.                                                                                                                                                                             In the current version (v1.1.0) only IMSI is supported""",
+    )
     path: int
+
 
 # Properties to return to client
 class UE(UEBase):
-    supi: constr(regex=r'^[0-9]{15,16}$') = Field(default="202010000000000", description= """String identifying a Supi that shall contain either an IMSI, a network specific identifier, a Global Cable Identifier (GCI) or a Global Line Identifier (GLI) as specified in clause 2.2A of 3GPP TS 23.003.                                                                                          
-                                                                                      In the current version (v1.1.0) only IMSI is supported""")
-    latitude: Optional[confloat(ge=-90, le=90)] 
-    longitude: Optional[confloat(ge=-180, le=180)]                                                                                      
+    supi: constr(regex=r"^[0-9]{15,16}$") = Field(
+        default="202010000000000",
+        description="""String identifying a Supi that shall contain either an IMSI, a network specific identifier, a Global Cable Identifier (GCI) or a Global Line Identifier (GLI) as specified in clause 2.2A of 3GPP TS 23.003.                                                                                          
+                                                                                      In the current version (v1.1.0) only IMSI is supported""",
+    )
+    latitude: Optional[confloat(ge=-90, le=90)]
+    longitude: Optional[confloat(ge=-180, le=180)]
     path_id: Optional[int]
     gNB_id: Optional[int]
     Cell_id: Optional[int]
-    
+
     class Config:
         orm_mode = True
 
-# Properties to return to client with cell id hex 
+
+# Properties to return to client with cell id hex
 class UEhex(UE):
     cell_id_hex: Optional[str]
     id: int

--- a/backend/app/app/static/js/dashboard-ues.js
+++ b/backend/app/app/static/js/dashboard-ues.js
@@ -407,6 +407,7 @@ function ui_add_btn_listeners_for_UEs_CUD_operations() {
           mcc                 : $('#add_UE_mcc').val(),
           mnc                 : $('#add_UE_mnc').val(),
           dnn                 : $('#add_UE_dnn').val(),
+          visiting_plmnid     : $('#add_UE_vplmnid').val(),
           // location & path
           path_id             : assign_path_id,
           speed               : $('#add_UE_speed').val(),
@@ -414,6 +415,8 @@ function ui_add_btn_listeners_for_UEs_CUD_operations() {
           Cell_id             : 1,
         };
 
+		if (!data.visiting_plmnid)
+			data.visiting_plmnid = null;
 
         add_UE_modal.hide();
 
@@ -442,10 +445,14 @@ function ui_add_btn_listeners_for_UEs_CUD_operations() {
         edit_UE_tmp_obj.description         = $('#edit_UE_description').val();
 
         // network
-        edit_UE_tmp_obj.ip_address_v4 = $('#edit_UE_ipv4').val();
-        edit_UE_tmp_obj.ip_address_v6 = $('#edit_UE_ipv6').val();
-        edit_UE_tmp_obj.mac_address   = $('#edit_UE_mac').val();
-        edit_UE_tmp_obj.msisdn        = $('#edit_UE_msisdn').val();
+        edit_UE_tmp_obj.ip_address_v4   = $('#edit_UE_ipv4').val();
+        edit_UE_tmp_obj.ip_address_v6   = $('#edit_UE_ipv6').val();
+        edit_UE_tmp_obj.mac_address     = $('#edit_UE_mac').val();
+        edit_UE_tmp_obj.msisdn          = $('#edit_UE_msisdn').val();
+        edit_UE_tmp_obj.visiting_plmnid = $('#edit_UE_vplmnid').val();
+
+		if (!edit_UE_tmp_obj.visiting_plmnid)
+			edit_UE_tmp_obj.visiting_plmnid = null;
 
         // location & path
         edit_UE_tmp_obj.path_id = assign_path_id;
@@ -505,6 +512,7 @@ function ui_show_edit_UE_modal( UE_supi ) {
     $('#edit_UE_mcc').val( edit_UE_tmp_obj.mcc );
     $('#edit_UE_mnc').val( edit_UE_tmp_obj.mnc );
     $('#edit_UE_cell').val( edit_UE_tmp_obj.cell_id_hex );
+    $('#edit_UE_vplmnid').val( edit_UE_tmp_obj.visiting_plmnid );
 
     $('#edit_UE_current_lat').val( edit_UE_tmp_obj.latitude );
     $('#edit_UE_current_lon').val( edit_UE_tmp_obj.longitude );

--- a/backend/app/app/tools/monitoring_callbacks.py
+++ b/backend/app/app/tools/monitoring_callbacks.py
@@ -1,8 +1,9 @@
 import logging
 import asyncio
 from typing import Optional
-from app import crud
+from collections.abc import Generator
 
+from app import crud
 from app.core.notification_responder import notification_responder
 from app.models.UE import UE
 from app.db.session import client
@@ -19,6 +20,14 @@ from app.schemas.monitoringevent import (
 )
 
 from app.api.deps import db_context
+
+
+def get_subscription_mon_types(sub) -> Generator[MonitoringType]:
+    yield sub["monitoringType"]
+
+    if sub.get("addnMonTypes") is not None:
+        for monType in sub.get("addnMonTypes"):
+            yield monType
 
 
 def update_maximum_reports(sub, id):

--- a/backend/app/app/ui/dashboard.html
+++ b/backend/app/app/ui/dashboard.html
@@ -665,6 +665,10 @@
                         <label for="edit_UE_cell" class="form-label">Cell</label>
                         <input type="text" class="form-control" id="edit_UE_cell" disabled>
                       </div>
+                      <div class="col-md-3">
+                        <label for="edit_UE_vplmnid" class="form-label">Visiting PLMN ID</label>
+                        <input type="text" class="form-control" id="edit_UE_vplmnid" placeholder="999-09">
+                      </div>
                       <!-- --------------------------------- -->
                       <div class="col-12 mt-4">
                         <h5>🔵 Current Location - path</h5>
@@ -754,7 +758,7 @@
                         <label for="add_UE_mac" class="form-label">MAC address</label>
                         <input type="text" class="form-control" id="add_UE_mac" value="22-00-00-00-00-01">
                       </div>
-                      <div class="col-md-3">
+                      <div class="col-md-4">
                         <label for="add_UE_msisdn" class="form-label">Phone Number (MSISDN)</label>
                         <input type="text" class="form-control" id="add_UE_msisdn" value="2020100000001">
                       </div>
@@ -770,6 +774,10 @@
                       <div class="col-md-4">
                         <label for="add_UE_dnn" class="form-label">dnn</label>
                         <input type="text" class="form-control" id="add_UE_dnn" value="province1.mnc01.mcc202.gprs" disabled>
+                      </div>
+                      <div class="col-md-4">
+                        <label for="add_UE_vplmnid" class="form-label">Visiting PLMN ID</label>
+                        <input type="text" class="form-control" id="add_UE_vplmnid" placeholder="999-09">
                       </div>
                       <!-- --------------------------------- -->
                       <div class="col-12 mt-4">


### PR DESCRIPTION
Adds a visiting PLMN ID attribute to the UE that if set indicates the device is roaming. This value can be directly changed in the frontend, doing so will cause all relevant subscriptions to be notified.