### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Function to determine Docker Compose command
 define docker_compose_cmd
-	$(if $(shell command -v docker-compose 2> /dev/null),docker-compose,$(if $(shell command -v docker compose 2> /dev/null),docker compose,))
+	$(if $(shell command -v docker compose 2> /dev/null),docker compose,$(if $(shell command -v docker-compose 2> /dev/null),docker-compose,))
 endef
 
 

--- a/backend/Dockerfile.backend
+++ b/backend/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
 
 WORKDIR /app/
 

--- a/backend/Dockerfile.report
+++ b/backend/Dockerfile.report
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11
 
 COPY ./report-app/src /app/src
 COPY /report-app/requirements.txt /app

--- a/backend/report-app/src/main.py
+++ b/backend/report-app/src/main.py
@@ -1,10 +1,16 @@
+import os
+import re
+
 from typing import Any
 from fastapi import Request, FastAPI
 from fastapi.responses import JSONResponse, FileResponse
-import os
-import json
 
 app = FastAPI()
+
+INVALID_PATH_REGEX = re.compile(r"\.|/|\\")
+
+def valid_filename(filename: str) -> bool:
+    return INVALID_PATH_REGEX.match(filename) is None
 
 @app.get("/")
 async def root():
@@ -16,12 +22,16 @@ def create_report(
     filename: str = 'report.json',
     http_request: Request
 ) -> Any:
-    if not os.path.exists("../shared/" + filename):
-        with open("../shared/" + filename, 'x') as jsonFile:
-            data = []
-            json.dump(data, jsonFile, indent=2)
-        return JSONResponse(content=f"Report named {filename} created",status_code=200)
-    return JSONResponse(content=f"Report named {filename} already exists",status_code=409)
+    if not valid_filename(filename):
+        return JSONResponse(content=f"Invalid filename",status_code=404)
+
+    try:
+        with open("../shared/" + filename, 'x') as _:
+            pass
+    except FileExistsError:
+        return JSONResponse(content=f"Report named {filename} already exists",status_code=409)
+
+    return JSONResponse(content=f"Report named {filename} created",status_code=200)
 
 
 @app.get("/report")
@@ -30,13 +40,14 @@ def get_report(
     filename: str = 'report.json',
     http_request: Request
 ) -> Any:
+    if not valid_filename(filename):
+        return JSONResponse(content=f"Invalid filename",status_code=404)
 
-    if not os.path.exists("../shared/" + filename):
-        return JSONResponse(content="File not Found",status_code=404)
-    
     report_path = os.path.abspath("../shared/" + filename)
+    if not os.path.exists(report_path):
+        return JSONResponse(content="File not Found",status_code=404)
 
-    return FileResponse(report_path,filename=filename)
+    return FileResponse(report_path, filename=filename, media_type="application/json-seq")
 
 @app.delete("/report")
 def delete_report(
@@ -44,7 +55,12 @@ def delete_report(
     filename: str = 'report.json',
     http_request: Request
 ) -> Any:
-    if os.path.exists("../shared/" + filename):
+    if not valid_filename(filename):
+        return JSONResponse(content=f"Invalid filename",status_code=404)
+
+    try:
         os.remove("../shared/" + filename)
-        return JSONResponse(content="Report deleted",status_code=200)
-    return JSONResponse(content="File not Found",status_code=404)
+    except FileNotFoundError:
+        return JSONResponse(content="File not Found",status_code=404)
+
+    return JSONResponse(content="Report deleted",status_code=200)


### PR DESCRIPTION
A collection of some fixes

- Fix error in backend when report file doesn't exist
- Fix path traversals in report application
- Use JSON text sequences for report instead of a big JSON array
  - Doesn't require reading the file every time
  - Consumes less memory
  - Allow for streaming from the file
- Makefile improvements
  - Use `/usr/bin/env bash` instead of `/bin/bash` since the latter isn't portable to all distributions
  - Prefer `docker compose` over `docker-compose` since the first is the newer version and the latter might not function correctly on certain systems
- Update container images to python 3.11. Needed because Poetry no longer installs in 3.9